### PR TITLE
Update "npm" to version 3.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "3.0.0",
     "github": "0.2.4",
-    "npm": "3.5.3",
+    "npm": "3.5.4",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "3.31.0"


### PR DESCRIPTION
#3.5.4 / 2016-01-08
- 3.5.4
- update AUTHORS
- doc: update changelog for 3.5.4
- glob@6.0.3
  Removes deprecated features.
  Fixes a host of bugs around dot files in ignores
  Credit: @isaacs
- has-unicode@2.0.0
  Change the default on windows to be false, as international windows installs
  often install to non-unicode codepages and there's no way to detect this short of
  a system call or a call to a command line program.
  Credit: @iarna
- tap@5.0.0
  New nyc, codecov.io AND coveralls.io support, t.end() multiple times is an error. Better windows support.
  Credit: @isaacs
- which@1.2.1
  Fixed bug when windows path parts are quoted.
  Fixed bug in uid / gid checks.
  Credit: @isaacs
- rimraf@2.5.0
  Adds ability to disable glob support / pass in options.
  Credit: @isaacs
- readable-stream@2.0.5
  Minor performance improvements
  Credit: @calvinmetcalf
- fs-write-stream-atomic@1.0.8
  Rewrite to use modern streams even on 0.8 plus a bunch of tests
  Credit: @iarna
- columnify@1.5.4
  Some bug fixes around large inputs
  Credit: @timoxley
- doc: Update default value for color variable
  PR-URL: https://github.com/npm/npm/pull/11044
  Credit: @scottaddie
- doc: drop mention of `process.installPrefix`
  process.installPrefix was removed here:
  https://github.com/nodejs/node-v0.x-archive/pull/3483.  It was
  announced here:
  https://github.com/jhnns/node/wiki/API-changes-between-v0.6-and-v0.8.
  PR-URL: https://github.com/npm/npm/pull/10990
  Credit: @jeffmcmahan
- doc: Correct the max length of the name property
  PR-URL: https://github.com/npm/npm/pull/11037
  Credit: @scottaddie
- doc: npm-dist-tag: s/"/`/g
  For uniformity with the docs for the "publish" command, use code formatting for tag names in the docs for the "dist-tag" command.
  PR-URL: https://github.com/npm/npm/pull/10787
  Credit: @cvrebert
- doc: npm-dist-tag: Explain how `latest` is special
  - Explain why one would care about the `latest` tag, by explaining its
    special significance to `npm install`.  Currently, only its default status
    with respect to `npm publish` is mentioned.
  - Also, avoid using npm as a meta-example, as this causes confusion between
    npm-the-tool and npm-the-project.  The old docs made it sound like the
    `next` tag might've has special significance to npm-the-tool, when it was
    instead talking about npm-the-project (AFAIK).
  - Mention common practice regarding tagging unstable releases, as this is
    not universally known.
  - Include the term "prerelease" for SEO's sake
    PR-URL: https://github.com/npm/npm/pull/10787
    Credit: @cvrebert
- doc: Link to tag docs in docs for `publish --tag`
  PR-URL: https://github.com/npm/npm/pull/10788
  Credit: @cvrebert
- doc: Add ref to first mention of "tag" in docs
  PR-URL: https://github.com/npm/npm/pull/10789
  Credit: @cvrebert
- doc: Clarify that default install ver is latest
  That is, that `npm install foo` ≡
  `npm install foo@latest` by default
  PR-URL: https://github.com/npm/npm/pull/10790
  Credit: @cvrebert
- src: always install in npm in legacy mode
  Also, clean out the docs and prune the tree before making a release
  tarball, to keep as much cruft as possible out of the release tarball.
  PR-URL: https://github.com/npm/npm/pull/10798
  Credit: @othiym23
- common-tap: Don't include the progress bar in test output
- test: sorted-package-json: don't stomp on error output
- test: mock just one fs function in no-scan-full-global-dir
- add-remote-tarball: work around node 0.8 http back-pressure bug
  0.8 http streams have a bug, where if they're paused with data in
  their buffers when the socket closes, they call `end` before emptying
  those buffers, which results in the entire pipeline ending and thus
  the point that applied backpressure never being able to trigger a
  `resume`.
  We work around this by piping into a pass through stream that has
  unlimited buffering. The pass through stream is from readable-stream
  and is thus a current streams3 implementation that is free of these
  bugs even on 0.8.
- src: Make fs-write-stream-atomic consistently referred to as writeStreamAtomic
- dep: Make readable-stream@2.0.2 a regular dependency
  Previously it was only used in tests, but we needed a modern pass through
  stream to provide buffering for 0.8 http streams, which have a bug around
  backpressure.
- test: Rewrite noargs-install-config-save to use common.npm
- test: install-link-scripts, no chmod on write in 0.8
- test: remove nock dependency
- test: Rewrite tests using nock to use other alternatives
