### PR TITLE
Update "npm" to version 3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "3.0.0",
     "github": "0.2.4",
-    "npm": "3.5.3",
+    "npm": "3.7.1",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "3.32.0"


### PR DESCRIPTION
#3.7.1 / 2016-02-01
- 3.7.1
- doc: update changelog for 3.7.1
- Revert "fetch-package-metadata: Use JSON clone instead of lodash.cloneDeep"
  This reverts commit 1d1ea7eeb958034878eb6573149aeecc686888d3.
  Fixes: [#11349](https://github.com/npm/npm/issues/11349)
  This was causing crashes due to cycles in metadata.
#3.7.0 / 2016-01-29
- 3.7.0
- update AUTHORS
- mailmap: Update with latest comitter emails
#3.6.0 / 2016-01-22
- 3.6.0
- update AUTHORS
- mailmap: Update with latest committer emails
- test: Only use Object.assign when available
- doc: update changelog for 3.6.0
- npm-registry-couchapp@2.6.12
  Dev dep.
  Update makes tests pass w/o sudo and also on @iarna's laptop.
  Credit: @iarna
- deps: node-gyp subsubdep updates
  ansi@0.3.1
  lodash.pad@3.2.0
  lodash.repeat@3.1.0
  path-array@1.0.1
  array-index@1.0.0
  es6-symbol@3.0.2
  d@0.1.1
  es5-ext@0.10.11
  es6-iterator@2.0.0
- deps: normalize-package-data subsubdeps update
  builtin-modules@1.1.1
- deps: npmlog subsubdeps update
  ansi@0.3.1
  lodash.pad@3.2.0
  lodash.repeat@3.1.0
- deps: read-installed subdeps update
  util-extend@1.0.3
- deps: request subdeps updates
  bl@1.0.1
  async@1.5.2
  har-validator@2.0.6
  escape-string-regexp@1.0.4
  is-my-json-valid@2.12.4
  sshpk@1.7.3
  dashdash@1.12.2
  tweetnacl@0.13.3
  mime-types@2.1.9
  mime-db@1.21.0
- deps: validate-npm-package-license subsubdep update
  spdx-correct@1.0.2
  spdx-license-ids@1.2.0
  spdx-expression-parse@1.0.2
  spdx-exceptions@1.0.4
  spdx-license-ids@1.2.0
- deps: fstream-npm subsubdep updates
  brace-expansion@1.1.2
- lodash.without@4.0.1
  Credit: @jdalton
- lodash.uniq@4.0.1
  Credit: @jdalton
- lodash.union@4.0.1
  Credit: @jdalton
- lodash.keys@4.0.0
- lodash.isarray@4.0.0
  Credit: @jdalton
- lodash.isarguments@3.0.5
  Credit: @jdalton
- lodash.clonedeep@4.0.1
  Bug fixes, including the non-linear performance that previously was biting npm.
  Credit: @jdalton
- tap@5.1.1
  You can pass in arguments to node and nyc now‼
  Credit: @isaacs
- config-chain@1.1.10
  Update tests for most recent version of ini
  Credit: @dominictarr
- gentlyrm: Don't abort early if npm controlled path is missing
  Previously if any of the npm controlled paths had an ENOENT then we would
  return fales from `isEverInside`– not an error condition, but a failed match.
  What we actually want to do is ONLY do that if ALL of the paths are ENOENT. If
  any aren't, then we want to test them normally.
  PR-URL: https://github.com/npm/npm/pull/11212
  Credit: @iarna
  Reviewed-By: @othiym23
- tests: Build on, rather than replace, common environment
  That is, previously some tests were running child npm's with from-scratch
  environments.  Instead this makes it build on what `common-npm` put
  together, making changes to that.  We need this because we needed a way for
  `common-npm` to suppress warnings about prerelease versions of node.
  PR-URL: https://github.com/npm/npm/pull/11212
  Credit: @iarna
  Reviewed-By: @othiym23
- common-tap: Suppress warnings about pre-release node versions
  PR-URL: https://github.com/npm/npm/pull/11212
  Credit: @iarna
  Reviewed-By: @othiym23
- validate: Only warn about pre-release versions of node in one place
  PR-URL: https://github.com/npm/npm/pull/11212
  Credit: @iarna
  Reviewed-By: @othiym23
- validate-args: Consume warnings from new npm-install-checks
  PR-URL: https://github.com/npm/npm/pull/11212
  Credit: @iarna
  Reviewed-By: @othiym23
- scripts: Add @iarna's changelog generator tool
  PR-URL: https://github.com/npm/npm/pull/11077
  Credit: @iarna
  Reviewed-By: ¯_(ツ)_/¯
  Reviewed-By: @othiym23
- doc: briefly explain what's included
  PR-URL: https://github.com/npm/npm/pull/11188
  Credit: @beaugunderson
  Reviewed-By: @othiym23
- install: fix unclean unbuild of nested packages with bin
  Previously, installed packages that contained node_modules with a .bin
  directory woudn't get cleaned up correctly. After unbuild of that particular
  package, npm would complain with ENOENT errors because the package directory
  would be empty (without package.json), as it only contains the leftover
  `node_modules/.bin` directory.
  PR-URL: https://github.com/npm/npm/pull/11181
  Credit: @chrisirhc
  Reviewed-By: @othiym23
  Fixes: [#10887](https://github.com/npm/npm/issues/10887)
  Fixes: [#10938](https://github.com/npm/npm/issues/10938)
- node-gyp-bin: fix custom node-gyp env var quoting
  npm sets node_config_node_gyp without quotes, so its usage should be
  quoted. Indeed, it is a better practice to define environment variables
  that contain paths without quotes and quote their usage.
  PR-URL: https://github.com/npm/npm/pull/11158
  Credit: @orangemocha
  Reviewed-By: @othiym23
- doc: advise use of `--depth Infinity` instead of `--depth 9999`
  PR-URL: https://github.com/npm/npm/pull/11150
  Credit: @halhenke
  Reviewed-By: @othiym23
- install: fix race condition correcting cache directory ownership
  Previously, correctMkdir() would cache the results early within its
  operation (after the stat, before calling chownr) meaning that any second
  call would immediately return the cached results, before the earlier chownr
  finishes.  This causes a race condition where the initial chownr would fail
  with ENOENT (or similar errors) trying to scan files that were being
  actively created/deleted/etc by the install process.  The fix guards the
  whole correctMkdir function with inflight() so that multiple calls do not do
  chownr simultaneously nor return early.  It would also be reasonable to not
  cache the results until after the chownr has finished, however that would
  still lead to an even more subtle race condition, so the guard on the whole
  call is required.
  PR-URL: https://github.com/npm/npm/pull/11142
  Credit: @Jimbly
  Reviewed-By: @othiym23
- readme: nuke "using npm programmatically" section
  The programmatic `npm` API is unsupported, and is not guaranteed not to break in non-major versions.
  Removing this section so newcomers aren't encouraged to discover or use it.
  PR-URL: https://github.com/npm/npm/pull/11130
  Credit: @ljharb
  Reviewed-By: @othiym23
- docs: Add link to local paths section
  Credit: @orangejulius
  Reviewed-By: @othiym23
  PR-URL: https://github.com/npm/npm/pull/11128
- outdated: report symlinked packages as 'linked'
  PR-URL: https://github.com/npm/npm/pull/11115
  Credit: @halhenke
  Reviewed-By: @othiym23
  Fixes: [#8752](https://github.com/npm/npm/issues/8752)
- doc: fix 3.5.4 release date in CHANGELOG.md
  Credit: @ashleygwilliams
  Reviewed-By: @othiym23
  PR-URL: https://github.com/npm/npm/pull/11090
- cache: ignore failures replacing package.json
  writeFileAtomic is not atomic in Windows, it fails if the file is
  being accessed concurrently.
  Fixes: [#7885](https://github.com/npm/npm/issues/7885)
  Fixes: [#9696](https://github.com/npm/npm/issues/9696)
  PR-URL: https://github.com/npm/npm/pull/10940
  Credit: @orangemocha
  Reviewed-By: @othiym23
- adduser: add a success message
  PR-URL: https://github.com/npm/npm/pull/10903
  Fixes: [#10775](https://github.com/npm/npm/issues/10775)
  Credit: @ekmartin
  Reviewed-By: @othiym23
- glob@6.0.4
- run-script: Warn if using script without install
  It might be helpful to remind people that they're trying to run
  a script before they actually run `npm install` on the package.
  PR-URL: https://github.com/npm/npm/pull/10043
  Credit: @timkrins
- version: strip tag-version-prefix from 'from-git' target tag
  PR-URL: https://github.com/npm/npm/pull/10717
  Credit: @ekmartin
- doc: add information about 'version from-git'
  PR-URL: https://github.com/npm/npm/pull/10717
  Credit: @ekmartin
- version: use readPackage helper
  PR-URL: https://github.com/npm/npm/pull/10717
  Credit: @ekmartin
- version: add 'npm version from-git' command
  PR-URL: https://github.com/npm/npm/pull/10717
  Credit: @ekmartin
- test: fix race condition in git tests
  Use the --reuseaddr flag when starting the git daemon in tests.
  While we can listen to a git server's process shutting down,
  there's no guarantee that the socket will have been returned to
  the OS by then, so the next server might still get an EADDRINUSE.
  PR-URL: https://github.com/npm/npm/pull/11127
  Credit: @zkat
- deps: dedupe after most recent round of dep updates
  PR-URL: https://github.com/npm/npm/pull/11129
  Credit: @iarna
- npm-install-checks@3.0.0
  PR-URL: https://github.com/npm/npm/pull/11129
  Credit: @iarna
- read-package-json@2.0.3
  PR-URL: https://github.com/npm/npm/pull/11129
  Credit: @iarna
- init-package-json@1.9.3
  PR-URL: https://github.com/npm/npm/pull/11129
  Credit: @iarna
#3.5.4 / 2016-01-08
- 3.5.4
- update AUTHORS
- doc: update changelog for 3.5.4
- glob@6.0.3
  Removes deprecated features.
  Fixes a host of bugs around dot files in ignores
  Credit: @isaacs
- has-unicode@2.0.0
  Change the default on windows to be false, as international windows installs
  often install to non-unicode codepages and there's no way to detect this short of
  a system call or a call to a command line program.
  Credit: @iarna
- tap@5.0.0
  New nyc, codecov.io AND coveralls.io support, t.end() multiple times is an error. Better windows support.
  Credit: @isaacs
- which@1.2.1
  Fixed bug when windows path parts are quoted.
  Fixed bug in uid / gid checks.
  Credit: @isaacs
- rimraf@2.5.0
  Adds ability to disable glob support / pass in options.
  Credit: @isaacs
- readable-stream@2.0.5
  Minor performance improvements
  Credit: @calvinmetcalf
- fs-write-stream-atomic@1.0.8
  Rewrite to use modern streams even on 0.8 plus a bunch of tests
  Credit: @iarna
- columnify@1.5.4
  Some bug fixes around large inputs
  Credit: @timoxley
- doc: Update default value for color variable
  PR-URL: https://github.com/npm/npm/pull/11044
  Credit: @scottaddie
- doc: drop mention of `process.installPrefix`
  process.installPrefix was removed here:
  https://github.com/nodejs/node-v0.x-archive/pull/3483.  It was
  announced here:
  https://github.com/jhnns/node/wiki/API-changes-between-v0.6-and-v0.8.
  PR-URL: https://github.com/npm/npm/pull/10990
  Credit: @jeffmcmahan
- doc: Correct the max length of the name property
  PR-URL: https://github.com/npm/npm/pull/11037
  Credit: @scottaddie
- doc: npm-dist-tag: s/"/`/g
  For uniformity with the docs for the "publish" command, use code formatting for tag names in the docs for the "dist-tag" command.
  PR-URL: https://github.com/npm/npm/pull/10787
  Credit: @cvrebert
- doc: npm-dist-tag: Explain how `latest` is special
  - Explain why one would care about the `latest` tag, by explaining its
    special significance to `npm install`.  Currently, only its default status
    with respect to `npm publish` is mentioned.
  - Also, avoid using npm as a meta-example, as this causes confusion between
    npm-the-tool and npm-the-project.  The old docs made it sound like the
    `next` tag might've has special significance to npm-the-tool, when it was
    instead talking about npm-the-project (AFAIK).
  - Mention common practice regarding tagging unstable releases, as this is
    not universally known.
  - Include the term "prerelease" for SEO's sake
    PR-URL: https://github.com/npm/npm/pull/10787
    Credit: @cvrebert
- doc: Link to tag docs in docs for `publish --tag`
  PR-URL: https://github.com/npm/npm/pull/10788
  Credit: @cvrebert
- doc: Add ref to first mention of "tag" in docs
  PR-URL: https://github.com/npm/npm/pull/10789
  Credit: @cvrebert
- doc: Clarify that default install ver is latest
  That is, that `npm install foo` ≡
  `npm install foo@latest` by default
  PR-URL: https://github.com/npm/npm/pull/10790
  Credit: @cvrebert
- src: always install in npm in legacy mode
  Also, clean out the docs and prune the tree before making a release
  tarball, to keep as much cruft as possible out of the release tarball.
  PR-URL: https://github.com/npm/npm/pull/10798
  Credit: @othiym23
- common-tap: Don't include the progress bar in test output
- test: sorted-package-json: don't stomp on error output
