### PR TITLE
Update "npm" to version 3.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "3.0.0",
     "github": "0.2.4",
-    "npm": "3.5.3",
+    "npm": "3.8.7",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "3.32.0"


### PR DESCRIPTION
<pre>3.8.7 / 2016-04-07
==================

  * 3.8.7
  * update AUTHORS
  * doc: changelog for 3.8.7
  * lifecycle: Add info log when ignore-scripts is true
    A global setting of `ignore-scripts:true` can cause `npm run-script` to silently fail to run scripts. This will add an info-level log
    PR-URL: https://github.com/npm/npm/pull/12083
    Credit: @bfred-it
    Reviewed-By: @iarna
  * tar: Improve handling of special cases for files included in packages
    Most notably, the package 'history' will not longer be included in the
    packages of anything which depends on it. Likewise with packages named
    changelog or license.
    This was fixed in fstream-npm@1.0.6 from via d82ff81403, but for some
    reason the internal tar code duplicated this logic. Removing the
    duplication passes all the tests, so seems prudent.
    While fixing this bug, it was noticed that the `files-and-ignores` tests
    were giving false positives because they use `npm install` instead of
    only `npm pack`, the tests have been modified to avoid this.
    See also [#9642](https://github.com/npm/npm/issues/9642), [#10445](https://github.com/npm/npm/issues/10445), [#11995](https://github.com/npm/npm/issues/11995)
    Credit: @glenjamin
    Reviewed-By: @zkat
    PR-URL: https://github.com/npm/npm/pull/11995
  * doc: Add 'login' as alias to 'adduser' cli command
    Credit: @gnerkus
    PR-URL: https://github.com/npm/npm/pull/12107
    Reviewed-By: @iarna
  * readme: Update Windows Upgrade Instructions
    With npm 3 being out for a while (and it being sooooo much better for Windows users), people will be better off with npm@3. This commit updates the readme with npm@3 update instructions.
    Credit: @felixrieseberg
    PR-URL: https://github.com/npm/npm/pull/12244
    Reviewed-By: @iarna
  * request@2.70.0
    A bunch of dep updates, accept read stream as body option, support JSON
    stringify replacer argument.
    Credit: @simov
  * lodash.keys@4.0.6
    Credit: @jdalton

3.8.6 / 2016-04-01
==================

  * 3.8.6
  * update AUTHORS
  * doc: bearer token security advisory in CHANGELOG
  * doc: update changelog for 3.8.6
  * doc: clarify the effects of defining `engines`
    The current behavior is when packages with an `engines` entry are
    installed a dependency npm produces a warning if necessary.
    PR-URL: https://github.com/npm/npm/pull/12147
    Credit: @reconbot
    Reviewed-By: @zkat
  * package-json: add make doc-clean to prepublish process
    PR-URL: https://github.com/npm/npm/pull/12146
    Credit: @watilde
    Reviewed-By: @zkat
  * makefile: add doc-clean to `make publish`
    PR-URL: https://github.com/npm/npm/pull/12146
    Credit: @watilde
    Reviewed-By: @zkat
  * faq: remove faq command as the docs was removed at [#10547](https://github.com/npm/npm/issues/10547)
    PR-URL: https://github.com/npm/npm/pull/12143
    Credit: @watilde
    Reviewed-By: @zkat
  * doc: remove faq link as it's removed at [#10547](https://github.com/npm/npm/issues/10547)
    PR-URL: https://github.com/npm/npm/pull/12143
    Credit: @watilde
    Reviewed-By: @zkat
  * package-json: update bugs url to https from http
    PR-URL: https://github.com/npm/npm/pull/12093
    Credit: @watilde
    Reviewed-By: @zkat
  * deprecate: default to `*` instead of `latest`
    When a semver spec is not supplied, npa supplies a default spec of
    'latest'. This is usually correct, but for deprecation the default has
    been to apply to all versions of a package.
    This patch just checks the raw spec and if it's empty it overrides with
    with the '*' version range, which is what people in the issue discussion
    were doing anyway.
    Fixes: https://github.com/npm/npm/issues/10974
    PR-URL: https://github.com/npm/npm/pull/12079
    Credit: @polm
    Reviewed-By: @zkat
  * doc: add --ignore-scripts flag to install doc page
    PR-URL: https://github.com/npm/npm/pull/12075
    Credit: @paulirish
    Reviewed-By: @zkat
  * html: update html/index.html
    + Update Node.js download link
    + Update README link
    + Remove FAQ link
    + Remove Mailing List link
    + Fix typo: thorougly => thoroughly
    PR-URL: https://github.com/npm/npm/pull/12063
    Credit: @watilde
    Reviewed-By: @zkat
  * lodash.without@4.1.2
    Credit: @jdalton
  * lodash.uniq@4.2.1
    Credit: @jdalton
  * lodash.union@4.2.1
    Credit: @jdalton
  * lodash.clonedeep@4.3.2
    Credit: @jdalton
  * lodash._baseuniq@4.5.1
    Credit: @jdalton

3.8.5 / 2016-03-25
==================

  * 3.8.5
  * update AUTHORS
  * doc: changelog for 3.8.5
  * link: fail if package link target is the same as package link source
    Credit: @antialias
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/11442
  * doc: Include `node_modules` in list of auto-excluded files
    Credit: @Jameskmonger
    PR-URL: https://github.com/npm/npm/pull/11884
    Reviewed-By: @iarna
  * search: Exit early if no arguments provided to search
    Fixes: [#11983](https://github.com/npm/npm/issues/11983)
    PR-URL: https://github.com/npm/npm/pull/11984
    Credit: @SimenB
    Reviewed-By: @iarna
  * test: Fix test that was inappropriately hitting the network
    Credit: @yodeyer
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/11987
  * deps: remove async-some that is no longer used
    Credit: @watilde
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12000
  * doc: Fix typo in npm-orgs documentation
    Credit: @yaelz
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12006

3.8.4 / 2016-03-24
==================

  * 3.8.4

3.8.3 / 2016-03-18
==================

  * 3.8.3
  * update AUTHORS
  * doc: changelog for 3.8.3
  * doc: fix small detail in npm-link docs
    This corrects a minor thing that popped up while reviewing
    https://github.com/npm/npm/pull/11820
    Credit: @zkat
    Reviewed-By: @iarna

3.8.2 / 2016-03-11
==================

  * 3.8.2
  * update AUTHORS
  * doc: changelog for 3.8.2
  * node-gyp@3.3.1
    Fix bug in builds for Android.
    Credit: @bnoordhuis
  * glob@7.0.3
    Fix a race condition and some windows edge cases.
    Credit: @isaacs
  * logout: Fix npm-logout to remove scope config if specified
    Fixes: [#10529](https://github.com/npm/npm/issues/10529)
    Credit: @wyze
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/11417
  * help: display all commands except for affordances
    Fixes: [#11003](https://github.com/npm/npm/issues/11003)
    PR-URL: https://github.com/npm/npm/pull/11761
    Credit: @watilde
    Reviewed-By: @iarna
  * npm: refactor command list into separate file
    PR-URL: https://github.com/npm/npm/pull/11761
    Credit: @watilde
    Reviewed-By: @iarna
  * config: include per-project .npmrc file in "npm config list"
    Credit: @mjomble
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/11475
    Fixes: [#11472](https://github.com/npm/npm/issues/11472)
  * doc: add command aliases to their respective docs
    Credit: @watilde
    PR-URL: https://github.com/npm/npm/pull/11748
    Reviewed-By: @othiym23
  * doc: Revert "advise use of `--depth Infinity` instead of `--depth 9999`"
    This reverts commit b463e3424b296cfc4bd384fc8bfe0e2329649164.
    PR-URL: https://github.com/npm/npm/pull/11762
    Fixes: [#11726](https://github.com/npm/npm/issues/11726)
    Credit: @GriffinSchneider
    Reviewed-By: @iarna
  * ls: Made `npm ls --parseable` honor the `depth` option
    Credit: @zacdoe
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/11773
    Fixes: [#11495](https://github.com/npm/npm/issues/11495)
  * config: Make the progress bars honor the unicode option
    Fixes: [#11781](https://github.com/npm/npm/issues/11781)
    PR-URL: https://github.com/npm/npm/pull/11782
    Credit: @watilde
    Reviewed-By: @iarna
  * doc: Note the required npm version in the npm-scope docs
    PR-URL: https://github.com/npm/npm/pull/11786
    Credit: @doug-wade
    Reviewed-By: @iarna
    Fixes: [#10968](https://github.com/npm/npm/issues/10968)
  * npm: Remove "verison" typo from npm command list
    Credit: @doug-wade
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/11787
    Fixes: [#11003](https://github.com/npm/npm/issues/11003)
  * view: Make npm produce valid JSON when requested with --json
    Previously it produced some sort of weird hybrid output, with multiple JSON
    docs.
    Credit: @doug-wade
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/11813
    Fixes: [#11808](https://github.com/npm/npm/issues/11808)
  * doc: fix description of npm-link
    The command `npm link` should be linking package from local folder to global,
    and `npm link package-name` should be from global to local. The current description
    is reversed.
    Credit: @rhgb
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/11820

3.8.1 / 2016-03-04
==================

  * 3.8.1
  * update AUTHORS
  * doc: update changelog for 3.8.1

3.8.0 / 2016-02-26
==================

  * 3.8.0
  * update AUTHORS

3.7.5 / 2016-02-23
==================

  * 3.7.5
  * build: Make sure ls on a clean repo works w/o error
  * doc: update changelog for 3.7.5</pre>
