### PR TITLE
Update "chai" to version 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-updater",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A tool that checks npm dependencies and sends a github pull request should updates be available",
   "main": "./index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "yargs": "4.5.0"
   },
   "devDependencies": {
-    "chai": "3.4.1",
+    "chai": "3.5.0",
     "eslint": "2.7.0",
     "mocha": "2.3.4",
     "sinon": "1.17.3",


### PR DESCRIPTION
<pre>3.5.0 / 2016-01-28
==================

  * Merge pull request [#601](https://github.com/chaijs/chai/issues/601) from keithamus/release-3.5.0
    chai@3.5.0
  * chai@3.5.0
  * Merge pull request [#589](https://github.com/chaijs/chai/issues/589) from qbolec/add-includedeepmembers
    Added includeDeepMembers
  * Added includeDeepMembers
  * Merge pull request [#579](https://github.com/chaijs/chai/issues/579) from chaijs/greenkeeper-karma-0.13.16
    Update karma to version 0.13.16 🚀
  * chore(package): update karma to version 0.13.16
    http://greenkeeper.io/
  * Merge pull request [#577](https://github.com/chaijs/chai/issues/577) from zetaben/patch-1
    Fix non ES5 compliant regexp
  * Fix non ES5 compliant regexp
    ES5 appears to require that { be escaped when not used as part of a quantifier. While this works fine in browsers it appears to choke less lenient runtimes (e.g. Duktape).
  * Merge pull request [#575](https://github.com/chaijs/chai/issues/575) from lucasfcosta/clean-browser-before-karma
    Clean browser before karma
  * Details on cleaning and testing on CONTRIBUTING.md
  * Run clean-browser before testing with karma
  * Merge pull request [#573](https://github.com/chaijs/chai/issues/573) from gdelmas/assert-isobject-documentation
    clarified assert.isObject & assert.isNotObject documentation
  * clarified assert.isObject & assert.isNotObject documentation
  * Merge pull request [#570](https://github.com/chaijs/chai/issues/570) from jurko-gospodnetic/fix-error-message-string-substitutions
    Fix error message string substitutions
  * fix error message tag substitution
    String.prototype.replace() had some extra undesireable substitution behaviour
    when it replaces a tag with a string containing some internal tags like `$$`,
    or `$'`.
    For more detailed information see:
    https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
  * split up getMessage() tests
  * Merge pull request [#567](https://github.com/chaijs/chai/issues/567) from outsideris/badges-for-chat
    add badges for Slack and Gitter
  * add badges for Slack and Gitter
    close [#564](https://github.com/chaijs/chai/issues/564)
  * Merge pull request [#566](https://github.com/chaijs/chai/issues/566) from lizhengnacl/master
    clerical error
  * clerical error
  * Merge pull request [#565](https://github.com/chaijs/chai/issues/565) from chaijs/add-code-of-conduct
    Add Code of Conduct
  * Add Code of Conduct
  * Merge pull request [#561](https://github.com/chaijs/chai/issues/561) from DavidBR-SW/Should_interface_docs
    Added JSDocs to 'should' interface</pre>
