### PR TITLE
Update "eslint" to version 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "chai": "3.4.1",
-    "eslint": "1.10.3",
+    "eslint": "2.7.0",
     "mocha": "2.3.4",
     "sinon": "1.17.2",
     "tmp": "0.0.28"


### PR DESCRIPTION
<pre>2.7.0 / 2016-04-04
==================

  * 2.7.0
  * Build: package.json and changelog update for 2.7.0
  * Merge pull request [#5787](https://github.com/eslint/eslint/issues/5787) from eslint/revert-5595-no-extra-parens-nested-binary-expressions
    Revert "Update: adds nestedBinaryExpressions for no-extra-parens rule…
  * Revert "Update: adds nestedBinaryExpressions for no-extra-parens rule (fixes [#3065](https://github.com/eslint/eslint/issues/3065))"
  * Merge pull request [#5785](https://github.com/eslint/eslint/issues/5785) from pedrottimark/fixable-rules
    Docs: Update sentence in fixable rules
  * Docs: Update sentence in fixable rules
  * Merge pull request [#5782](https://github.com/eslint/eslint/issues/5782) from zpao/eslint-indent-class-decl
    Fix: indent rule uses wrong node for class indent level (fixes [#5764](https://github.com/eslint/eslint/issues/5764))
  * Merge pull request [#5595](https://github.com/eslint/eslint/issues/5595) from spadgos/no-extra-parens-nested-binary-expressions
    Update: adds nestedBinaryExpressions for no-extra-parens rule (fixes [#3065](https://github.com/eslint/eslint/issues/3065))
  * Update: adds nestedBinaryExpressions for no-extra-parens (fixes [#3065](https://github.com/eslint/eslint/issues/3065))
  * Merge pull request [#5772](https://github.com/eslint/eslint/issues/5772) from eslint/issue5768
    Docs: Clarify `array-bracket-spacing` with newlines (fixes [#5768](https://github.com/eslint/eslint/issues/5768))
  * Docs: Clarify `array-bracket-spacing` with newlines (fixes [#5768](https://github.com/eslint/eslint/issues/5768))
  * Merge pull request [#5771](https://github.com/eslint/eslint/issues/5771) from eslint/core/remove-console
    Fix: remove `console.dir` (fixes [#5770](https://github.com/eslint/eslint/issues/5770))
  * Fix: remove `console.dir` (fixes [#5770](https://github.com/eslint/eslint/issues/5770))
  * Fix: improve `constructor-super` errors for literals (fixes [#5449](https://github.com/eslint/eslint/issues/5449))
    Fix: wrong path on non-blocked if statements.
    Fix: improve `constructor-super` error messages
  * Fix: indent rule uses wrong node for class indent level (fixes [#5764](https://github.com/eslint/eslint/issues/5764))
  * 2.6.0
  * Build: package.json and changelog update for 2.6.0

2.6.0 / 2016-04-01
==================

  * Merge pull request [#5762](https://github.com/eslint/eslint/issues/5762) from olmokramer/olmokramer-export-vars-on-top
    Fix: vars-on-top conflicts with `export`
  * Fix: vars-on-top now accepts exported variables (fixes [#5711](https://github.com/eslint/eslint/issues/5711))
  * Merge pull request [#5624](https://github.com/eslint/eslint/issues/5624) from eslint/prefer-const/mixed-option
    Update: `destructuring` option of `prefer-const` rule (fixes [#5594](https://github.com/eslint/eslint/issues/5594))
  * Merge pull request [#5755](https://github.com/eslint/eslint/issues/5755) from onurtemizkan/no-useless-escape/adding-B-escape
    Fix: no-useless-escape \B regex escape (fixes [#5750](https://github.com/eslint/eslint/issues/5750))
  * Merge pull request [#5743](https://github.com/eslint/eslint/issues/5743) from vitorbal/max_option
    Update: Deprecate option `maximum` in favor of `max` (fixes [#5685](https://github.com/eslint/eslint/issues/5685))
  * Update: Deprecate option `maximum` in favor of `max` (fixes [#5685](https://github.com/eslint/eslint/issues/5685))
    Add the option name `max` to all rules that currently accept an option
    name `maximum`, and add deprecation notes to the docs of each of those
    rules.
  * Fix: no-useless-escape \B regex escape (fixes [#5750](https://github.com/eslint/eslint/issues/5750))
  * Update: `destructuring` option of `prefer-const` rule (fixes [#5594](https://github.com/eslint/eslint/issues/5594))
  * Merge pull request [#5706](https://github.com/eslint/eslint/issues/5706) from isaacl/master
    Improve no-param-reassign props: true msg
  * Merge pull request [#5747](https://github.com/eslint/eslint/issues/5747) from eslint/issue-5745
    Fix: valid-jsdoc crash w/ Field & Array Type
  * Merge pull request [#5753](https://github.com/eslint/eslint/issues/5753) from eslint/docs-sort-imports
    Docs: Typo in `sort-imports`
  * Docs: Typo in `sort-imports`
  * Fix: valid-jsdoc crash w/ Field & Array Type (fixes [#5745](https://github.com/eslint/eslint/issues/5745)) (fixes [#5746](https://github.com/eslint/eslint/issues/5746))
    Introduces deep and more robust `preferType` checks to `valid-jsdoc`.
  * Merge pull request [#5752](https://github.com/eslint/eslint/issues/5752) from pedrottimark/edit-examples
    Docs: Edit examples for a few rules
  * Docs: Edit examples for a few rules
  * Merge pull request [#5741](https://github.com/eslint/eslint/issues/5741) from scottohara/5718-lines-around-comment
    Fix: Treat SwitchCase like a block in lines-around-comment (fixes [#5718](https://github.com/eslint/eslint/issues/5718))
  * Merge pull request [#5740](https://github.com/eslint/eslint/issues/5740) from eslint/no-useless-escape/allow-line-breaks
    Update: make `no-useless-escape` allowing line breaks (fixes [#5689](https://github.com/eslint/eslint/issues/5689))
  * Fix: Treat SwitchCase like a block in lines-around-comment (fixes [#5718](https://github.com/eslint/eslint/issues/5718))
    When allowBlockStart/allowBlockEnd are true, comments at the start/end
    of a switch case are treated the same as if they were in a block
  * Update: make `no-useless-escape` allowing line breaks (fixes [#5689](https://github.com/eslint/eslint/issues/5689))
  * Merge pull request [#5712](https://github.com/eslint/eslint/issues/5712) from eslint/issue5175
    Fix: Ensure proper lookup of config files (fixes [#5175](https://github.com/eslint/eslint/issues/5175))
  * Fix: Ensure proper lookup of config files (fixes [#5175](https://github.com/eslint/eslint/issues/5175), fixes [#5468](https://github.com/eslint/eslint/issues/5468))
  * Merge pull request [#5717](https://github.com/eslint/eslint/issues/5717) from eslint/fixes5612
    Fix: Update doctrine to allow hyphens in JSDoc names (fixes [#5612](https://github.com/eslint/eslint/issues/5612))
  * Merge pull request [#5733](https://github.com/eslint/eslint/issues/5733) from morrissinger/master
    Fix: Old Chalk.JS deprecated method (fixes [#5716](https://github.com/eslint/eslint/issues/5716))
  * Fix: Update doctrine to allow hyphens in JSDoc names (fixes [#5612](https://github.com/eslint/eslint/issues/5612))
  * Upgrade: Old Chalk.JS deprecated method (fixes [#5716](https://github.com/eslint/eslint/issues/5716))
  * Merge pull request [#5730](https://github.com/eslint/eslint/issues/5730) from Jameskmonger/patch-1
    Docs: Correct explanation about properties
  * Update: no-param-reassign error msgs (fixes [#5705](https://github.com/eslint/eslint/issues/5705))
    - Change error message if rule triggers from prop side effect
    vs from setting param directly.
    This fixes [#5705](https://github.com/eslint/eslint/issues/5705).
  * Merge pull request [#5729](https://github.com/eslint/eslint/issues/5729) from zaygraveyard/issue5724
    Fix: Object spread throws error in key-spacing rule. (fixes [#5724](https://github.com/eslint/eslint/issues/5724))
  * Fix: Object spread throws error in key-spacing rule. (fixes [#5724](https://github.com/eslint/eslint/issues/5724))
  * Docs: Correct explanation about properties
  * Merge pull request [#5720](https://github.com/eslint/eslint/issues/5720) from eslint/gyandeeps-patch-1
    Fix: Lint issue with `valid-jsdoc` rule (refs [#5188](https://github.com/eslint/eslint/issues/5188))
  * Fix: Lint issue with `valid-jsdoc` rule (refs [#5188](https://github.com/eslint/eslint/issues/5188))
  * Merge pull request [#5652](https://github.com/eslint/eslint/issues/5652) from tgandrews/add-basic-jsdoc-default-param-support
    Update: Basic valid-jsdoc default parameter support (fixes [#5658](https://github.com/eslint/eslint/issues/5658))
  * Merge pull request [#5713](https://github.com/eslint/eslint/issues/5713) from eslint/lintFix
    Fix: Lint for eslint project in regards to vars (refs [#5188](https://github.com/eslint/eslint/issues/5188))
  * Merge pull request [#5715](https://github.com/eslint/eslint/issues/5715) from eslint/issue5714
    Build: Ignore jsdoc folder internally (fixes [#5714](https://github.com/eslint/eslint/issues/5714))
  * Build: Ignore jsdoc folder internally (fixes [#5714](https://github.com/eslint/eslint/issues/5714))
  * Fix: Lint for eslint project in regards to vars (refs [#5188](https://github.com/eslint/eslint/issues/5188))
  * Merge pull request [#5710](https://github.com/eslint/eslint/issues/5710) from eslint/issue5644
    Fix: Windows scoped package configs (fixes [#5644](https://github.com/eslint/eslint/issues/5644))
  * Fix: Windows scoped package configs (fixes [#5644](https://github.com/eslint/eslint/issues/5644))
  * Update: Basic valid-jsdoc default parameter support (fixes [#5658](https://github.com/eslint/eslint/issues/5658))
    Improve tests

2.5.3 / 2016-03-28
==================

  * 2.5.3
  * Build: package.json and changelog update for 2.5.3
  * Merge pull request [#5708](https://github.com/eslint/eslint/issues/5708) from eslint/issue5687
    Build: Disable bundling dependencies (fixes [#5687](https://github.com/eslint/eslint/issues/5687))
  * Build: Disable bundling dependencies (fixes [#5687](https://github.com/eslint/eslint/issues/5687))

2.5.2 / 2016-03-28
==================

  * 2.5.2
  * Build: package.json and changelog update for 2.5.2
  * Merge pull request [#5700](https://github.com/eslint/eslint/issues/5700) from eslint/docs-readme-faq
    Docs: Reorder FAQ in README
  * Merge pull request [#5702](https://github.com/eslint/eslint/issues/5702) from eslint/doc-eslintignore
    Docs: Remove mention of minimatch for .eslintignore
  * Docs: Remove mention of minimatch for .eslintignore
    We no longer use minimatch for ignore patterns, instead using `ignore`
    to match `.gitignore` format exactly.
  * Merge pull request [#5699](https://github.com/eslint/eslint/issues/5699) from eslint/issue5698
    Fix: Correct default for indentation in `eslint --init` (fixes [#5698](https://github.com/eslint/eslint/issues/5698))
  * Docs: Reorder FAQ in README
  * Fix: Correct default for indentation in `eslint --init` (fixes [#5698](https://github.com/eslint/eslint/issues/5698))
  * Merge pull request [#5697](https://github.com/eslint/eslint/issues/5697) from eslint/core/fix-default-of-cliengine-cwd
    Fix: make the default of `options.cwd` in runtime (fixes [#5694](https://github.com/eslint/eslint/issues/5694))
  * Fix: make the default of `options.cwd` in runtime (fixes [#5694](https://github.com/eslint/eslint/issues/5694))
  * Merge pull request [#5683](https://github.com/eslint/eslint/issues/5683) from TheAlphaNerd/validate-before-using-path
    fix: don't use path.extname with undefined value
  * Merge pull request [#5506](https://github.com/eslint/eslint/issues/5506) from pedrottimark/distinguish-examples-best-practices-2
    Docs: Distinguish examples in rules under Best Practices part 2
  * Docs: Distinguish examples in rules under Best Practices part 2
  * Merge pull request [#5688](https://github.com/eslint/eslint/issues/5688) from eslint/issue5680
    Build: Fix bundling script (fixes [#5680](https://github.com/eslint/eslint/issues/5680))</pre>
