### PR TITLE
Update "mocha" to version 2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "chai": "3.5.0",
     "eslint": "2.7.0",
-    "mocha": "2.3.4",
+    "mocha": "2.4.5",
     "sinon": "1.17.3",
     "tmp": "0.0.28"
   }


### PR DESCRIPTION
<pre>2.4.5 / 2016-01-28
==================

  * Release v2.4.5
  * update CHANGELOG.md for forthcoming v2.4.5 release
  * reverts usage of chalk and all chalk-related changes thereafter; closes [#2080](https://github.com/mochajs/mocha/issues/2080)
    reverts:
    - 4b37877bc0ab72b6782a8a5b38fbb86a6a2a3475
    - a4345efe0de0f80d09b35794f5e130d730542def
    - 9f3774f7beaad3f26d88313205ff6796a84b2f83
    - 119291449cd03a11cdeda9e37cf718a69a012896
  * add npm-debug.log to .gitignore
  * Merge pull request [#2082](https://github.com/mochajs/mocha/issues/2082) from mislav/fix-assertions
    Fix a number of assertions that weren't asserting anything
  * Fix a number of assertions that weren't asserting anything
    They were missing parentheses and thus no assertion method was ever executed.
  * Mark `.skip()` as public API
    Users are supposed to call `this.skip()` from tests and suite hooks, so
    this is definitely a public API.
  * Strenghten checks across the board for pending/skipped tests or suites
    Checking for boolean property `.pending` on Test or Suite objects was
    too brittle in a way that the caller often forgot to check whether any
    of the object's parents are marked as pending as well.
    This moves all the pending checks to new `.isPending()` predicate method
    that is defined on all Suite and Runnable (and thus Test and Hook as
    well.)
    Runners and reporters should always use this method to check for
    "pendingness" of test and suite objects.

2.4.4 / 2016-01-27
==================

  * Release v2.4.4
  * update changelog
  * use browser field instead of --require; closes [#2080](https://github.com/mochajs/mocha/issues/2080)
  * Merge pull request [#2076](https://github.com/mochajs/mocha/issues/2076) from rstacruz/patch-2
    Add missing heading style

2.4.3 / 2016-01-27
==================

  * Release v2.4.3
  * stub chalk in browser, closes [#2078](https://github.com/mochajs/mocha/issues/2078)
  * Add missing heading style

2.4.2 / 2016-01-27
==================

  * Release v2.4.2
  * rebuild
  * update CHANGELOG; add link to CHANGELOG in README.md
  * Merge pull request [#2074](https://github.com/mochajs/mocha/issues/2074) from gyandeeps/master
    Fix: reporters with chalk functions (fixes [#2073](https://github.com/mochajs/mocha/issues/2073))
  * Fix: reporters with chalk functions (fixes [#2073](https://github.com/mochajs/mocha/issues/2073))
  * Merge pull request [#2072](https://github.com/mochajs/mocha/issues/2072) from thedark1337/master
    Fix [#2071](https://github.com/mochajs/mocha/issues/2071): Removed color code to fix Chalk colors
  * Fix [#2071](https://github.com/mochajs/mocha/issues/2071): Removed color code to fix Chalk colors
  * Merge pull request [#2053](https://github.com/mochajs/mocha/issues/2053) from mislav/window-vs-global
    Have global exports be compatible with Web Workers

2.4.1 / 2016-01-26
==================

  * Release v2.4.1
  * rebuild mocha.js
  * rename HISTORY.md => CHANGELOG.md
  * increase retry test timeout
  * Merge pull request [#2068](https://github.com/mochajs/mocha/issues/2068) from danielstjules/dstjules/test-body
    Fix 2067: HTML/DOC reporter regression with async failures
  * Fix [#2067](https://github.com/mochajs/mocha/issues/2067): HTML/DOC reporter regression with async failures
  * Build browser mocha for 2.4.0
  * Release 2.4.0
  * Merge pull request [#2066](https://github.com/mochajs/mocha/issues/2066) from danielstjules/dstjules/fix-browser
    Fix test fn's being deleted too early for browser reporter
  * Fix test fn's being deleted too early for browser reporter
  * Merge pull request [#1945](https://github.com/mochajs/mocha/issues/1945) from ryanshawty/master
    Correctly skip tests when skipping in a suites before()
  * Correctly skip tests when skipping in a suites before()
  * Merge pull request [#2056](https://github.com/mochajs/mocha/issues/2056) from pra85/patch-1
    chore(license): update license year to 2016
  * chore(license): update license year to 2016
  * Have global exports be compatible with Web Workers
    Assigning to `window` only works in a normal browser environment;
    however, Web Workers don't have access to `window`. Instead, the global
    object inside Web Workers is `self`.
    Browserify ensures that `global` is present to all scripts by creating a
    shim reference to it using this logic:
    typeof global !== "undefined" ? global :
    typeof self !== "undefined" ? self :
    typeof window !== "undefined" ? window : {}
    Thus, if neither `global` nor `self` were originally present,
    `global === window` will be true.
    Web Workers compatibility was broken in a81e5558.
  * Fix integration tests: remove .only()
  * Merge pull request [#2048](https://github.com/mochajs/mocha/issues/2048) from mislav/fix-skip
    Fix `this.skip` from spec with HTML reporter
  * Enable `this.skip()` within individual test at runtime
    References [#946](https://github.com/mochajs/mocha/issues/946)
  * Merge pull request [#2047](https://github.com/mochajs/mocha/issues/2047) from longlho/retry-fix
    add clone capability to test, fix async retry, fix [#2045](https://github.com/mochajs/mocha/issues/2045)
  * add clone capability to test, fix async retry, fix [#2045](https://github.com/mochajs/mocha/issues/2045)
  * Merge pull request [#2033](https://github.com/mochajs/mocha/issues/2033) from tomhughes/should
    Update tests for newer versions of should.js
  * Merge pull request [#2037](https://github.com/mochajs/mocha/issues/2037) from bd82/master
    Fix for memory leak caused by referenced to deferred test functions
  * Merge pull request [#2038](https://github.com/mochajs/mocha/issues/2038) from bd82/travis
    Also run Travis-CI on node.js 4 & 5
  * Also run travis build on node.js 4 & 5.
  * Fix for memory leak caused by referenced to deferred test functions
    (it/before[Each]/after[Each]).
    related to [#1991](https://github.com/mochajs/mocha/issues/1991).
  * Update tests for newer versions of should.js
  * Bump mkdirp to 0.5.1 to support strict mode
  * Merge pull request [#2028](https://github.com/mochajs/mocha/issues/2028) from stonelgh/remove-reference-to-test-try2
    Remove reference to test before afterAll hook runs
  * Remove reference to test before afterAll hook runs
    Fix [#2006](https://github.com/mochajs/mocha/issues/2006)
  * Merge pull request [#1977](https://github.com/mochajs/mocha/issues/1977) from ahamid/handle-phantomjs-undefined
    safely stringify PhantomJS undefined value
  * safely stringify PhantomJS undefined value
  * Merge pull request [#1989](https://github.com/mochajs/mocha/issues/1989) from longlho/1773-retries
    Allow to retry failed test from test context for [#1773](https://github.com/mochajs/mocha/issues/1773)
  * Merge pull request [#1982](https://github.com/mochajs/mocha/issues/1982) from Alaneor/cli-log-timer-events
    Enable --log-timer-events option
  * Enable --log-timer-events option
    This provides better insights when profiling application using --prof switch. Especially useful when the log is processed by https://v8.googlecode.com/svn/branches/bleeding_edge/tools/profviz/profviz.html.
  * Allow to retry failed test from test context for [#1773](https://github.com/mochajs/mocha/issues/1773)
    - make retries run proper hooks
    - allow retries override at different levels
    - expose currentRetry to reporters
  * Fix [#1980](https://github.com/mochajs/mocha/issues/1980): Load mocha.opts from bin/mocha and bin/_mocha
  * Merge pull request [#1976](https://github.com/mochajs/mocha/issues/1976) from iclanzan/patch-1
    Simplify function call.
  * Merge branch 'ui-fix'
  * Fix fixtures/regression/1794/simple-ui.js to work with local mocha
  * 1794 test case
  * Merge pull request [#1963](https://github.com/mochajs/mocha/issues/1963) from peachworks/perf-basic-prof
    Add support --perf-basic-prof
  * Merge pull request [#1981](https://github.com/mochajs/mocha/issues/1981) from Standard8/fix-done-reporting-on-html
    Fix HTML reporting display to show errors if done is called multiple times, or if an exception is thrown after done is called.
  * Merge pull request [#1993](https://github.com/mochajs/mocha/issues/1993) from segrey/master
    propagate "file" property across suites and tests for "exports" inter…
  * Merge pull request [#1999](https://github.com/mochajs/mocha/issues/1999) from tmont/use-strict-fix
    support for strict mode
  * Merge pull request [#2005](https://github.com/mochajs/mocha/issues/2005) from jonnyreeves/patch-1
    XUnit Reporter Writes to stdout, falls back to console.log
  * Alter feature detection
  * Merge pull request [#2021](https://github.com/mochajs/mocha/issues/2021) from zetaben/patch-1
    Fix non ES5 compliant regexp
  * Merge pull request [#1965](https://github.com/mochajs/mocha/issues/1965) from cowboyd/dont-double-install-bdd-ui
    Dont double install bdd ui
  * always reference the correct it from it.only
  * Fix non ES5 regexp
    ES5 appears to require that { be escaped when not used as part of a quantifier. While this works fine in browsers it appears to choke less lenient runtimes (e.g. Duktape)
  * Fix HTML reporting display to show errors if done is called multiple times, or if an exception is thrown after done is called.
  * XUnit Reporter Writes to stdout, falls back to console.log
    Fixes [#1674](https://github.com/mochajs/mocha/issues/1674); provides support *much* needed for [mocha-phantomjs](https://github.com/nathanboktae/mocha-phantomjs) (see [[#133](https://github.com/mochajs/mocha/issues/133)](https://github.com/nathanboktae/mocha-phantomjs/issues/133), [[#220](https://github.com/mochajs/mocha/issues/220)](https://github.com/nathanboktae/mocha-phantomjs/issues/220), etc).  Maintains support for running the XUnit reporter in a browser (unlike the previously reverted PR [#1068](https://github.com/mochajs/mocha/issues/1068)).
    ping @alemangui, @nathanboktae
    Thanks all.
  * support for strict mode
    - fixes [#1879](https://github.com/mochajs/mocha/issues/1879)
    - fixes [#1821](https://github.com/mochajs/mocha/issues/1821)
  * Merge pull request [#1995](https://github.com/mochajs/mocha/issues/1995) from ianwremmel/fix-xunit-hang
    make sure the xunit output dir exists before trying to write to it
  * fix lint errors</pre>
