### PR TITLE
Update "yargs" to version 4.6.0-candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "npm": "3.8.7",
     "semver": "5.1.0",
     "underscore": "1.8.3",
-    "yargs": "4.5.0"
+    "yargs": "4.6.0-candidate"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
<pre>4.6.0-candidate / 2016-04-11
============================

  * chore(release): 4.6.0
  * feat: switch to standard-version for release management
  * feat: upgrade to version of yargs-parser that introduces some slick new features, great work @elas7. update cliui, replace win-spawn, replace badge. ([#475](https://github.com/yargs/yargs/issues/475))
  * docs(license): update license to reflect work undertaken since project was forked from optimist
  * fix(my brand!): I agree with @osher lightweight isn't a huge selling point of ours any longer, see [#468](https://github.com/yargs/yargs/issues/468)
  * docs: fix link in docs, add link to our new standard-changelog format ([#473](https://github.com/yargs/yargs/issues/473))</pre>
