### PR TITLE
Update "npm" to version 3.8.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.0.0",
     "github": "0.2.4",
-    "npm": "3.8.7",
+    "npm": "3.8.9",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "4.6.0"


### PR DESCRIPTION
<pre>3.8.9 / 2016-04-29
==================

  * 3.8.9
  * update AUTHORS
  * doc: changelog for 3.8.9
  * lib: Refactor summary usage to use utils/usage
    This also helps by DRYing up our lists of command aliases.
    Credit: @watilde
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12485
  * utils: add usage summary generator
    Credit: @watilde
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12485
  * config: document run alias for run-script
    Credit: @watilde
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12485
  * fetch-package-metadata: Ensure _resolved always available.
    Fixes: [#12347](https://github.com/npm/npm/issues/12347)
    Credit: @sminnee
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12426
  * view: fix view versions without --json
    Credit: @watilde
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12450
    Fixes: [#12009](https://github.com/npm/npm/issues/12009)
  * ci: nix iojs, add Node.js 6, prioritize 4 over 5
    Credit: @othiym23
    PR-URL: https://github.com/npm/npm/pull/12487
    Reviewed-By: @iarna
  * tacks@1.2.1
    New features & refactoring.
    Credit: @iarna
  * read-package-json@2.0.4
    Made the error code you get on windows match that from unix if you try
    to read a package.json from a path that includes a file, not a folder.
    Credit: @zkat

3.8.8 / 2016-04-22
==================

  * 3.8.8
  * update AUTHORS
  * doc: changelog for 3.8.8
  * install: failing to parse package.json should be error
    Credit: @watilde
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12406
  * doc: Reworded "cert" and "key" explanation
    "cert" and "key" wording uses the same structure as "ca" wording.
    Credit: @rvedotrc
    PR-URL: https://github.com/npm/npm/pull/12415
  * doc: clarify that "cert" and "key" are not paths
    Credit: @rvedotrc
    PR-URL: https://github.com/npm/npm/pull/12415
  * test: Fix progress config testing to ignore local user configs
    Previously, _any_ local setting would cause the tests to fail as
    they were trying to test what the default values for the progress
    bar would be in different environments and any explicit setting
    overrides those defaults.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12329
  * doc: Describe how `npm run` sets `NODE` and `PATH` in more detail
    Note that `npm run` changes `PATH` to include the current node
    interpreter’s directory.
    Credit: @addaleax
    PR-URL: https://github.com/npm/npm/pull/12324
  * test: get rid of legacy test command from test-node
    Credit: @zkat
    PR-URL: https://github.com/npm/npm/pull/12310
  * test: lifecycle-signal v0.8 compatibility fix
    `Number.parseInt` is not available on 0.8, but `parseInt` is.
    Credit: @iarna
  * doc: Clarify homepage url documentation
    Credit: @stevemao
    PR-URL: https://github.com/npm/npm/pull/11461
    Reviewed-By: @iarna
  * realize-package-specifier@3.0.3
    Resolve spec field for local & dir specs, working in conjunction with the
    new npa that doesn't do this any more.
  * npm-package-arg@4.1.1
    Fix some file:// urls on windows
    Stop resolving local paths in npa (this is now done in
    realze-package-specifier)
    Credit: @zkat
  * fs-vacuum@1.2.9
    Code cleanup, CI & dep updates.
    A fix for AIX where a non-empty directory can cause `fs.rmDir` to fail with `EEXIST` instead of `ENOTEMPTY`
    and three new tests
    Credit: @othiym23
    Credit: @richardlau
  * tap@5.7.1
    Credit: @isaacs
  * request@2.72.0
    Don't throw if invalid characters are found in an http header, emit via an
    error event.
    Fix crashes when response headers indicate gzipped content but the body is
    empty.
    Add `request.delete` as an alias for `del`
    Add support for deflate content encoding.
    Credit: @simov</pre>
