### PR TITLE
Update "npm" to version 3.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.0.0",
     "github": "0.2.4",
-    "npm": "3.9.0",
+    "npm": "3.9.1",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "4.7.0"


### PR DESCRIPTION
<pre>3.9.1 / 2016-05-13
==================

  * mailmap: updates for authors
  * 3.9.1
  * update AUTHORS
  * doc: changelog for 3.9.1
  * inflate-shrinkwrap: Inflate nested dependencies within a shrinkwrap
    PR-URL: https://github.com/npm/npm/pull/12373
    Fixes: [#12372](https://github.com/npm/npm/issues/12372)
    Credit: @misterbyrne
    Reviewed-By: @iarna
  * test: Rewrite shrinkwrap-version-match to use tacks
    Rewritten while extracting the test from the PR into its own thing.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12290
  * extract: Propagate read-package-tree errors for bundled dependencies
    This protects against a crasher when a bundled dep is missing a package.json
    (or index.js with embedded package.json data).
    PR-URL: https://github.com/npm/npm/pull/12476
    Credit: @dflupu
  * ci: mask coveralls token in nexted invocation
    PR-URL: https://github.com/npm/npm/pull/12550
    Credit: @othiym23
    Reviewed-By: @iarna
  * test: disable coverage in recursively-called tap
    PR-URL: https://github.com/npm/npm/pull/12550
    Credit: @othiym23
    Reviewed-By: @iarna
  * doc: engineStrict is quite gone
    Not "deprecated" so much as "extirpated".
    Credit: @othiym23
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12585
  * doc: Improve documentation of when `node-gyp` is used.
    PR-URL: https://github.com/npm/npm/pull/12636
    Credit: @reconbot
    Reviewed-By: @iarna
  * doc: Correct documentation as to when `node-gyp rebuild` is called
    This now matches https://docs.npmjs.com/misc/scripts#default-values
  * lodash._baseuniq@4.6.0
    Credit: @jdalton
  * lodash.keys@4.0.7
    Credit: @jdalton
  * lodash.union@4.4.0
    Credit: @jdalton
  * lodash.uniq@4.3.0
    Credit: @jdalton
  * lodash.without@4.2.0
    Credit: @jdalton</pre>
