### PR TITLE
Update "yargs" to version 4.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "npm": "3.9.0",
     "semver": "5.1.0",
     "underscore": "1.8.3",
-    "yargs": "4.7.0"
+    "yargs": "4.7.1"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
<pre>4.7.1 / 2016-05-15
==================

  * docs: call out @jameswomack
  * chore(release): 4.7.1
  * fix: use const as a semantic tool ([#502](https://github.com/yargs/yargs/issues/502))
    fix: use const as a semantic tool
  * chore: use const as a semantic tool
    Philosophy behind this: http://womack.io/2016/01/05/Const-ant-Craving/
    tldr;
    * `const` has been supported in Node.js since at least 0.4
    * `const` makes code more readable—it's clear a value won't change
    * standard helps w/ this by pointing out when `const` is misused
  * fix: make stdout flush on newer versions of Node.js ([#501](https://github.com/yargs/yargs/issues/501))
    * test: add failing test for [#497](https://github.com/yargs/yargs/issues/497)
    * fix: created shim that sets stdout/stderr to blocking when we know we're about to exit
    * fix: OSX tests need a bit more running time
    * fix: for the sake of Browserify, also check for _handle
    * chore: pulled setBlocking shim into its own module</pre>
