### PR TITLE
Update "eslint" to version 2.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "eslint": "2.9.0",
+    "eslint": "2.10.2",
     "mocha": "2.4.5",
     "sinon": "1.17.4",
     "tmp": "0.0.28"


### PR DESCRIPTION
<pre>2.10.2 / 2016-05-16
===================

  * 2.10.2
  * Build: package.json and changelog update for 2.10.2
  * Fix: Remove default parser from CLIEngine options (fixes [#6182](https://github.com/eslint/eslint/issues/6182)) ([#6183](https://github.com/eslint/eslint/issues/6183))
    * Fix: Remove default parser from CLIEngine options (fixes [#6182](https://github.com/eslint/eslint/issues/6182))
    * Fix: Ensure correct parser is used (fixes [#6182](https://github.com/eslint/eslint/issues/6182))
  * Docs: Describe options in rules under Possible Errors part 3 ([#6105](https://github.com/eslint/eslint/issues/6105))
  * Build: Run phantomjs tests using karma (fixes [#6128](https://github.com/eslint/eslint/issues/6128)) ([#6178](https://github.com/eslint/eslint/issues/6178))

2.10.1 / 2016-05-14
===================

  * 2.10.1
  * Build: package.json and changelog update for 2.10.1
  * Fix: `valid-jsdoc` false positive at default parameters (fixes [#6097](https://github.com/eslint/eslint/issues/6097)) ([#6170](https://github.com/eslint/eslint/issues/6170))
  * Fix: warning & error count in `CLIEngine.getErrorResults` (fixes [#6155](https://github.com/eslint/eslint/issues/6155)) ([#6157](https://github.com/eslint/eslint/issues/6157))
  * Fix: ignore empty statements in max-statements-per-line (fixes [#6153](https://github.com/eslint/eslint/issues/6153)) ([#6156](https://github.com/eslint/eslint/issues/6156))
  * Fix: `no-extra-parens` to check for nulls (fixes [#6161](https://github.com/eslint/eslint/issues/6161)) ([#6164](https://github.com/eslint/eslint/issues/6164))
  * Fix: Parser merge sequence in config (fixes [#6158](https://github.com/eslint/eslint/issues/6158)) ([#6160](https://github.com/eslint/eslint/issues/6160))
  * Fix: `no-return-assign` to check for null tokens (fixes [#6159](https://github.com/eslint/eslint/issues/6159)) ([#6162](https://github.com/eslint/eslint/issues/6162))

2.10.0 / 2016-05-13
===================

  * 2.10.0
  * Build: package.json and changelog update for 2.10.0
  * Docs: Distinguish examples in rules under Stylistic Issues part 4 ([#6136](https://github.com/eslint/eslint/issues/6136))
  * Docs: Clarify JSX option usage ([#6132](https://github.com/eslint/eslint/issues/6132))
    * Make it clear that you need to do more than just enable JSX to get useful linting when JSX is used
    * Remove space that is white
    * Reword note about JSX support to be less React.js-centrix
  * Fix: Optimize no-irregular-whitespace for the common case (fixes [#6116](https://github.com/eslint/eslint/issues/6116)) ([#6117](https://github.com/eslint/eslint/issues/6117))
  * Docs: linkify URLs in development-environment.md ([#6150](https://github.com/eslint/eslint/issues/6150))
  * Docs: Convert rules in index under Removed from list to table ([#6091](https://github.com/eslint/eslint/issues/6091))
  * Fix: `_` and `$` in isES5Constructor (fixes [#6085](https://github.com/eslint/eslint/issues/6085)) ([#6094](https://github.com/eslint/eslint/issues/6094))
    As discussed in [#6085](https://github.com/eslint/eslint/issues/6085), the previous case-matching code was overly
    liberal in matching these punctuation characters, which are not commonly
    used to begin constructor names.  In the case that they are used, such
    uses may be excluded from the relevant rules using inline configuration.
    Changes in v2:
    - After further discussion, reduce the matching to only characters which
    differ from their lower-cased versions.  This has a higher chance of
    false-negatives, but false-negatives can be worked around by
    configuration while false-positives can not.
  * Fix: `no-loop-func` crashed (fixes [#6130](https://github.com/eslint/eslint/issues/6130)) ([#6138](https://github.com/eslint/eslint/issues/6138))
  * Fix: Sort fixes consistently even if they overlap (fixes [#6124](https://github.com/eslint/eslint/issues/6124)) ([#6133](https://github.com/eslint/eslint/issues/6133))
  * Docs: Correct syntax for default ignores and `.eslintignore` example ([#6118](https://github.com/eslint/eslint/issues/6118))
  * Fix: Replace `assert.deepEqual` by `lodash.isEqual` (fixes [#6111](https://github.com/eslint/eslint/issues/6111)) ([#6112](https://github.com/eslint/eslint/issues/6112))
  * Fix: `no-multiple-empty-lines` duplicate errors at BOF (fixes [#6113](https://github.com/eslint/eslint/issues/6113)) ([#6114](https://github.com/eslint/eslint/issues/6114))
  * Docs: Document `--ignore-pattern` ([#6120](https://github.com/eslint/eslint/issues/6120))
  * Fix: Merge various command line configs at the same time (fixes [#6104](https://github.com/eslint/eslint/issues/6104)) ([#6108](https://github.com/eslint/eslint/issues/6108))
  * Update: add returnAssign option to no-extra-parens (fixes [#6036](https://github.com/eslint/eslint/issues/6036)) ([#6095](https://github.com/eslint/eslint/issues/6095))
  * Build: Use split instead of slice/indexOf for commit check (fixes [#6109](https://github.com/eslint/eslint/issues/6109)) ([#6110](https://github.com/eslint/eslint/issues/6110))
  * Docs: Update headings of rules under Removed (refs [#5774](https://github.com/eslint/eslint/issues/5774)) ([#6102](https://github.com/eslint/eslint/issues/6102))
  * Build: Match rule id at beginning of heading (refs [#5774](https://github.com/eslint/eslint/issues/5774)) ([#6089](https://github.com/eslint/eslint/issues/6089))
  * Update: Add an option to `prefer-const` (fixes [#5692](https://github.com/eslint/eslint/issues/5692)) ([#6040](https://github.com/eslint/eslint/issues/6040))
  * Update: Add autofix for `lines-around-comment` (fixes [#5956](https://github.com/eslint/eslint/issues/5956)) ([#6062](https://github.com/eslint/eslint/issues/6062))
  * Build: Pin proxyquire to ">=1.0.0 <1.7.5" (fixes [#6096](https://github.com/eslint/eslint/issues/6096)) ([#6100](https://github.com/eslint/eslint/issues/6100))
  * Docs: Describe options in rules under Possible Errors part 2 ([#6063](https://github.com/eslint/eslint/issues/6063))
  * Chore: Replace deprecated calls to context - batch 4 (fixes [#6029](https://github.com/eslint/eslint/issues/6029)) ([#6087](https://github.com/eslint/eslint/issues/6087))
  * Fix: `no-return-assign` warning nested expressions (fixes [#5913](https://github.com/eslint/eslint/issues/5913)) ([#6041](https://github.com/eslint/eslint/issues/6041))
  * Merge pull request [#6088](https://github.com/eslint/eslint/issues/6088) from eslint/docs-one-var-per-line
    Docs: Improve showcase example in `one-var-declaration-per-line`
  * Docs: Correct default for `one-var-declaration-per-line` (fixes [#6017](https://github.com/eslint/eslint/issues/6017)) ([#6022](https://github.com/eslint/eslint/issues/6022))
  * Fix: comma-style accounts for parens in array (fixes [#6006](https://github.com/eslint/eslint/issues/6006)) ([#6038](https://github.com/eslint/eslint/issues/6038))
  * Docs: Fix typography/teriminology in indent doc (fixes [#6045](https://github.com/eslint/eslint/issues/6045)) ([#6044](https://github.com/eslint/eslint/issues/6044))
  * Chore: Replace deprecated calls to context - batch 3 (refs [#6029](https://github.com/eslint/eslint/issues/6029)) ([#6056](https://github.com/eslint/eslint/issues/6056))
  * Update: multipass should not exit prematurely (fixes [#5995](https://github.com/eslint/eslint/issues/5995)) ([#6048](https://github.com/eslint/eslint/issues/6048))
  * Update: Adds an avoidQuotes option for object-shorthand (fixes [#3366](https://github.com/eslint/eslint/issues/3366)) ([#5870](https://github.com/eslint/eslint/issues/5870))
  * Fix: throw when rule uses `fix` but `meta.fixable` not set (fixes [#5970](https://github.com/eslint/eslint/issues/5970)) ([#6043](https://github.com/eslint/eslint/issues/6043))
    Throw an error when a rule uses `fix` but has no `meta.fixable`
    property set.
  * Docs: Update comma-style docs ([#6039](https://github.com/eslint/eslint/issues/6039))
  * Fix: `no-sequences` false negative at arrow expressions (fixes [#6082](https://github.com/eslint/eslint/issues/6082)) ([#6083](https://github.com/eslint/eslint/issues/6083))
  * Docs: Clarify rule example in README since we allow string error levels ([#6061](https://github.com/eslint/eslint/issues/6061))
  * Fix: `lines-around-comment` multiple errors on same line (fixes [#5965](https://github.com/eslint/eslint/issues/5965)) ([#5994](https://github.com/eslint/eslint/issues/5994))
  * Docs: Organize meta and describe visitor in Working with Rules ([#5967](https://github.com/eslint/eslint/issues/5967))
  * Fix: object-shorthand should only lint computed methods (fixes [#6015](https://github.com/eslint/eslint/issues/6015)) ([#6024](https://github.com/eslint/eslint/issues/6024))
  * Chore: Replace deprecated calls to context - batch 2 (refs [#6029](https://github.com/eslint/eslint/issues/6029)) ([#6049](https://github.com/eslint/eslint/issues/6049))
  * Update: no-irregal-whitespace in a regular expression (fixes [#5840](https://github.com/eslint/eslint/issues/5840)) ([#6018](https://github.com/eslint/eslint/issues/6018))
    Problem:
    no-irregal-whitespace ignores string literals correctly, but doen't
    regular expressions. ([#5840](https://github.com/eslint/eslint/issues/5840))
    Solution:
    Also check that the node is a regular expression in
    removeInvalidNodeErrorsInIdentifierOrLiteral().
    Added below options to no-irregal-whitespace
    - skipStrings (default: true)
    - skipRegExps (default: false)
    - skipTemplates (default: false)
  * Chore: Replace deprecated calls to context - batch 1 (refs [#6029](https://github.com/eslint/eslint/issues/6029)) ([#6034](https://github.com/eslint/eslint/issues/6034))
  * Fix: blockless else in max-statements-per-line (fixes [#5926](https://github.com/eslint/eslint/issues/5926)) ([#5993](https://github.com/eslint/eslint/issues/5993))
    Previously `if (x) var y = 1; else var z = 1;` was allowed, now it isnt
  * New: Add new rule `object-property-newline` (fixes [#5667](https://github.com/eslint/eslint/issues/5667)) ([#5933](https://github.com/eslint/eslint/issues/5933))
    Add a new rule `object-property-newline` that is a port from
    JSCS requireObjectKeysOnNewLine.
  * Docs: mention parsing errors in strict mode (fixes [#5485](https://github.com/eslint/eslint/issues/5485)) ([#5991](https://github.com/eslint/eslint/issues/5991))
  * Docs: Move docs from eslint.github.io (fixes [#5964](https://github.com/eslint/eslint/issues/5964)) ([#6012](https://github.com/eslint/eslint/issues/6012))
  * Docs: Add example of diff clarity to comma-dangle rule docs ([#6035](https://github.com/eslint/eslint/issues/6035))
    Add a sentence and a code example about diff clarity to
    comma-dangle docs.
  * Fix: Do not swallow exceptions in CLIEngine.getFormatter (fixes [#5977](https://github.com/eslint/eslint/issues/5977)) ([#5978](https://github.com/eslint/eslint/issues/5978))
    * Fix: Do not swallow exceptions (fixes [#5977](https://github.com/eslint/eslint/issues/5977))
    If a formatter is broken, the exception telling you that it was
    broken would be swallowed by the catch block, and the error
    reporting would tell you that it could not find the formatter.
    I discovered a bug in npm3 (that I haven't reported yet) which took
    longer to find than it should, because I was running in circles
    to try and figure out why it couldn't find the formatter.
    This fix means that any exception, that is not a result of the
    formatter module not being found, will be re-thrown.
    * fix up unrelated test
    * rethrow all errors with new message
    * use assert.throws
    * try/catch around getFormatter now as it will throw on invalid formatter names
  * Fix: Always ignore defaults unless explicitly passed (fixes [#5547](https://github.com/eslint/eslint/issues/5547)) ([#5820](https://github.com/eslint/eslint/issues/5820))
    * Fix: Always ignore defaults unless explicitly passed (fixes [#5547](https://github.com/eslint/eslint/issues/5547))
    * Base ignore message on type of ignore
    * Tweak ignore warning messages
  * Docs: Add example of diff clarity to newline-per-chained-call ([#5986](https://github.com/eslint/eslint/issues/5986))
  * Docs: Update readme info about jshint ([#6027](https://github.com/eslint/eslint/issues/6027))
  * Docs: put config example in code block ([#6005](https://github.com/eslint/eslint/issues/6005))
    Quotes outside of code blocks are turned into smart quotes, which makes
    them impractical to copy&paste into a code editor.
    Also turns error severity from number to string.
  * Docs: Fix a wrong examples' header of `prefer-arrow-callback`. ([#6020](https://github.com/eslint/eslint/issues/6020))
  * Docs: Typo in nodejs-api ([#6025](https://github.com/eslint/eslint/issues/6025))
  * Docs: typo: "eslint-disable-line" not "eslint disable-line" ([#6019](https://github.com/eslint/eslint/issues/6019))
  * Fix: Removed false positives of break and continue (fixes [#5972](https://github.com/eslint/eslint/issues/5972)) ([#6000](https://github.com/eslint/eslint/issues/6000))</pre>
