### PR TITLE
Update "npm" to version 3.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.0.0",
     "github": "0.2.4",
-    "npm": "3.9.0",
+    "npm": "3.9.3",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "4.7.0"


### PR DESCRIPTION
<pre>3.9.3 / 2016-05-19
==================

  * 3.9.3
  * doc: update changelog for 3.9.3
  * read-package-tree@5.1.4
    Don't mark a module as linked just because its node_modules is a link.
    Credit: @iarna
    Fixes: [#10013](https://github.com/npm/npm/issues/10013)
    PR-URL: https://github.com/npm/npm/pull/12756
    Reviewed-By: @othiym23
  * ls: fix filter when prerelease version present
    If `ls` for a package without using a semver filter,
    for example, `npm ls foo` vs `foo@1.2.3`, `ls` was using semver
    ranges based on `*`, which doesn't match prerelease versions.
    So, if you had installed a prerelease version (`foo@1.2.3-xyz`),
    the `npm ls` will return no results for `foo`, at all.
    This patch bypasses the semver check entirely when there's no semver
    filter for the search.
    Fixes: https://github.com/npm/npm/issues/9436
    Credit: @zkat
    PR-URL: https://github.com/npm/npm/pull/12685
    Reviewed-By: @othiym23
  * test: adding some basic npm ls tests
    Credit: @zkat
    PR-URL: https://github.com/npm/npm/pull/12685
    Reviewed-By: @othiym23
  * which@1.2.9
    Fix for paths startin with ../
    Credit: @isaacs
  * readable-stream@2.1.3
    Node 6 build and buffer updates
    Credit: @calvinmetcalf
  * init-package-json@1.9.4
    Stop using `package` for a variable, which defeats some bundlers and linters.
    Credit: @adius
    PR-URL: https://github.com/npm/init-package-json/pull/62
  * inflight@1.0.5
  * hosted-git-info@2.1.5
  * fstream-npm@1.1.0
    `fstream-npm` always includes NOTICE files now.
    Credit: @kemitchell
    PR-URL: https://github.com/npm/fstream-npm/pull/17

3.9.2 / 2016-05-18
==================

  * 3.9.2
  * update AUTHORS
  * doc: changelog for 3.9.2
  * inflate-shrinkwrap: Fix crasher when inflating shrinkwraps
    Fixes: [#12724](https://github.com/npm/npm/issues/12724)
    PR-URL: https://github.com/npm/npm/pull/12724
    Credit: @iarna

3.9.1 / 2016-05-13
==================

  * mailmap: updates for authors
  * 3.9.1
  * update AUTHORS
  * doc: changelog for 3.9.1
  * inflate-shrinkwrap: Inflate nested dependencies within a shrinkwrap
    PR-URL: https://github.com/npm/npm/pull/12373
    Fixes: [#12372](https://github.com/npm/npm/issues/12372)
    Credit: @misterbyrne
    Reviewed-By: @iarna
  * test: Rewrite shrinkwrap-version-match to use tacks
    Rewritten while extracting the test from the PR into its own thing.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12290
  * extract: Propagate read-package-tree errors for bundled dependencies
    This protects against a crasher when a bundled dep is missing a package.json
    (or index.js with embedded package.json data).
    PR-URL: https://github.com/npm/npm/pull/12476
    Credit: @dflupu
  * ci: mask coveralls token in nexted invocation
    PR-URL: https://github.com/npm/npm/pull/12550
    Credit: @othiym23
    Reviewed-By: @iarna
  * test: disable coverage in recursively-called tap
    PR-URL: https://github.com/npm/npm/pull/12550
    Credit: @othiym23
    Reviewed-By: @iarna
  * doc: engineStrict is quite gone
    Not "deprecated" so much as "extirpated".
    Credit: @othiym23
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/12585
  * doc: Improve documentation of when `node-gyp` is used.
    PR-URL: https://github.com/npm/npm/pull/12636
    Credit: @reconbot
    Reviewed-By: @iarna
  * doc: Correct documentation as to when `node-gyp rebuild` is called
    This now matches https://docs.npmjs.com/misc/scripts#default-values
  * lodash._baseuniq@4.6.0
    Credit: @jdalton
  * lodash.keys@4.0.7
    Credit: @jdalton
  * lodash.union@4.4.0
    Credit: @jdalton
  * lodash.uniq@4.3.0
    Credit: @jdalton
  * lodash.without@4.2.0
    Credit: @jdalton</pre>
