### PR TITLE
Update "npm" to version 3.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
     "github": "0.2.4",
-    "npm": "3.9.3",
+    "npm": "3.9.4",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "4.7.1"


### PR DESCRIPTION
<pre>3.9.4 / 2016-05-26
==================

  * 3.9.4
  * update AUTHORS
  * doc: update changelog for 3.9.4
  * test: Rewrite shrinkwrap-prod-dependency-also to use common.npm
    Reviewed-By: @zkat
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12851
  * test: cleanup rm-linked
    Reviewed-By: @zkat
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12851
  * test: cleanup outdated-symlink
    Reviewed-By: @zkat
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12851
  * test: Improve diagnostics for shrinkwrap-scoped-auth
    Reviewed-By: @zkat
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12851
  * test: rewrite shrinkwrap-dev-dependency as common.npm
    Reviewed-By: @zkat
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12851
  * tar: fix prograssbar section name
    Without this you get `pack:[object Object]`.
    Reviewed-By: @zkat
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12845
  * doc: remove sexualized language from comment
    Reviewed-By: @zkat
    Credit: @geek
    PR-URL: https://github.com/npm/npm/pull/12840
  * doc: small grammar fix in cli/npm.md
    Reviewed-By: @zkat
    Credit: @andresilveira
    PR-URL: https://github.com/npm/npm/pull/12802
  * doc: Add `NOTICE` to files included in pack
    `NOTICE` files started getting included after
    https://github.com/npm/fstream-npm/pull/17. This documents that.
    Reviewed-By: @zkat
    Credit: @SimenB
    PR-URL: https://github.com/npm/npm/pull/12782
  * doc: remove mention of `<pkg>` arg for `run-script`
    It looks like it was not updated with current `npm run-script` syntax,
    since it now acceps only one parameter.
    If I am not wrong, running scripts of `<pkg>` dependencies was supported
    in previous versions (what a pity it was removed), so I updated
    documentation.
    Reviewed-By: @zkat
    Credit: @fibo
    PR-URL: https://github.com/npm/npm/pull/12776
  * aproba@1.0.3
    Credit: @iarna</pre>
