### PR TITLE
Update "npm" to version 3.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
     "github": "0.2.4",
-    "npm": "3.9.4",
+    "npm": "3.9.5",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "4.7.1"


### PR DESCRIPTION
<pre>3.9.5 / 2016-05-28
==================

  * 3.9.5
  * update AUTHORS
  * doc: update changelog for 3.9.5
  * npmignore: ignore .nyc_output
    This will help avoid an accidental publish or commit filled with
    code coverage data
    Fixes: https://github.com/npm/npm/issues/12873
    Credit: @TheAlphaNerd
    PR-URL: https://github.com/npm/npm/pull/12878
    Reviewed-By: @zkat</pre>
