### PR TITLE
Update "eslint" to version 2.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "eslint": "2.11.0",
+    "eslint": "2.11.1",
     "mocha": "2.5.3",
     "sinon": "1.17.4",
     "tmp": "0.0.28"


### PR DESCRIPTION
<pre>2.11.1 / 2016-05-30
===================

  * 2.11.1
  * Build: package.json and changelog update for 2.11.1
  * Fix: failed to parse `/*eslint` comments by colon (fixes [#6224](https://github.com/eslint/eslint/issues/6224)) ([#6258](https://github.com/eslint/eslint/issues/6258))
    It came to use Optionator to parse the comments by the same way as
    parsing CLI option. But Optionator cannot parse commaless notation, so
    there is a fallback for that.
  * Build: Don't check commit count (fixes [#5935](https://github.com/eslint/eslint/issues/5935)) ([#6263](https://github.com/eslint/eslint/issues/6263))
  * Fix: `max-statements-per-line` false positive at exports (fixes [#6264](https://github.com/eslint/eslint/issues/6264)) ([#6268](https://github.com/eslint/eslint/issues/6268))
  * Fix: `no-useless-rename` false positives (fixes [#6266](https://github.com/eslint/eslint/issues/6266)) ([#6267](https://github.com/eslint/eslint/issues/6267))
  * Docs: Fix rule name in example ([#6279](https://github.com/eslint/eslint/issues/6279))</pre>
