### PR TITLE
Update "npm" to version 3.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
     "github": "1.1.2",
-    "npm": "3.9.6",
+    "npm": "3.10.0",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "4.7.1"


### PR DESCRIPTION
<pre>3.10.0 / 2016-06-17
===================

  * 3.10.0
  * update AUTHORS
  * doc: update changelog for 3.10.0
  * tar: warn when using Node 6+
    Credit: @othiym23
    PR-URL: https://github.com/npm/npm/pull/13077
  * wrappy@1.0.2
    No consumer visible changes.
    Credit: @zkat
  * which@1.2.10
    Fix bug where unnecessary special case path handling for Windows could
    produce unexpected results on Unix systems.
    Credit: @isaacs
  * tap@5.7.2
    Credit: @isaacs
  * readable-stream@2.1.4
    No consumer visible changes.
    Credit: @calvinmetcalf
  * npm-user-validate@0.1.4
    Validate the length of usernames.
    Credit: @aredridel
  * npm-package-arg@4.2.0
    Add `escapedName` to the result.  It is suitable for passing through to a
    registry without further processing.
    Credit: @nexdrew
  * glob@7.0.4
    Fixes issues with Node 6 and "long or excessively symlink-looping paths"
    Credit: @isaacs
  * abbrev@1.0.9
    No meaningful changes.
    Credit: @isaacs
  * deps: Use asap in preference over process.nextTick to avoid recursion warnings
    Under the hood, `asap` uses `setImmediate` when available and falls back to
    `process.nextTick` when its not.  Versions of node that don't support
    `setImmediate` have a version of `process.nextTick` that actually behaves
    like the current `setImmediate`.
    Fixes: [#12754](https://github.com/npm/npm/issues/12754)
    PR-URL: https://github.com/npm/npm/pull/13021
    Credit: @lxe
  * asap@2.0.4
    PR-URL: https://github.com/npm/npm/pull/13021
    Credit: @lxe
  * doc: Describe how to run lifecycle scripts of dependencies.
    Prior to npm version 2, you could do this with `npm run <packagename>
    <scriptname>`.  These days, npm run can pass arguments through to the
    script instead.
    Related to the removal of the earlier possibility of running these scripts
    with npm run <pkg> <script> (removed from this doc in
    [npm/npm@70a3ae4](https://github.com/npm/npm/commit/70a3ae4d4ec76b3ec51f00bf5261f1147829f9fe)).
    Workaround mentioned in [npm/npm[#9186](https://github.com/npm/npm/issues/9186)](https://github.com/npm/npm/issues/9186).
    Ref [npm/docs[#704](https://github.com/npm/npm/issues/704)](https://github.com/npm/docs/issues/704).
    PR-URL: https://github.com/npm/npm/pull/12983
    Credit: @Tapppi
  * outdated: Stop colorizing the Location and Package Type columns.
    Previously they were colored dark gray, which was hard to read for some
    users.
    PR-URL: https://github.com/npm/npm/pull/12843
    Credit: @tribou
  * shrinkwrap: Add new "shrinkwrap" lifecycle script
    Fixes: [#10744](https://github.com/npm/npm/issues/10744)
    Credit: @SimenB
    PR-URL: https://github.com/npm/npm/pull/12814
  * test: check-install-self: Don't hide output
    PR-URL: https://github.com/npm/npm/pull/13075
    Credit: @iarna
  * require-inject@1.4.0
    Credit: @iarna
  * output: Standardize how we write to stdout
    This allows us to consistently make sure that the progress bar is hidden
    before we try to write to stdout.
    PR-URL: https://github.com/npm/npm/pull/13075
    Credit: @iarna
  * npm: Only enable progressbar if we have a tty
    With the older version of gauge (and thus the older version of npmlog), if
    you didn't have a tty then `gauge.enable` was ignored.  This is no longer
    the case, so now we need to do tty detection before enabling it ourselves.
    As a bonus, this now means tty detection is done exactly the same way for
    the progress bar as it is for color.
    PR-URL: https://github.com/npm/npm/pull/13075
    Credit: @iarna
  * progress-bars: Make sure we turn off progress bars when running stuff
    Be more methodical about disabling progress bars before running external
    commands.
    PR-URL: https://github.com/npm/npm/pull/13075
    Credit: @iarna
  * tar: Better progress indicators
    PR-URL: https://github.com/npm/npm/pull/13075
    Credit: @iarna
  * npmlog@3.1.2
    Bring in the new npmlog that uses the updated gauge.
    PR-URL: https://github.com/npm/npm/pull/13075
    Credit: @iarna
  * npm-registry-client@7.1.2
    Bring in a new npm-registry-client that can use our newer npmlog.
    PR-URL: https://github.com/npm/npm/pull/13075
    Credit: @iarna
  * npm: Wait to enable logging & progress bars till after configuration
    PR-URL: https://github.com/npm/npm/pull/13075
    Credit: @iarna
  * test: Verify that mixed symlinks won't result in moving modules
    Tests: [#10800](https://github.com/npm/npm/issues/10800)
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * node: Get rid of entirely redundent isLink check
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * node: Default version via the template
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: Maintain and reset missing(Dev)Deps values
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * todo: Add notes about eventually calls to recalculateMetadata
    It's used to generate logical relationships from physical relationships and
    should only ever be called after loading something like this off disk.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * mutate-into-logical-tree: Flag missing dev deps
    This allows `ls` to, when asked to show dev dependences, eg,
    `npm ls --dev`, complain about missing dev deps.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * deps: Rewrite how recalculateMetadata follows dependencies
    We keep track of missing dependencies and missing dev dependencies
    separately. This allows things like `npm ls` to make decisions about what
    it wants to warn about.
    Despite having concrete lists of dependencies and dev dependencies we were
    guessing as to which was which. This _usually_ works fine, but in cases where
    dependencies and dev dependencies share a requirement but not precisely the
    same version, it could lead to misleading error messages.
    Further, things in the shrinkwrap that are not in the package.json were not being
    reported at all.
    This change does two things:
    1. It rewrites `markDeps` to take an object with name, spec & kind (`prod`
    or `dev`). Previously it took a string of `name@spec` and extracted name
    & spec from that.
    2. When a dependency is both a prod and a dev dep, it will be correctly
    categorized. Previously if the dev spec didn't match it would still be
    flagged as a prod mismatch.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: Remove install pruning stage
    This has been obsoleted by steps taken by the installer itself to keep its
    tree clear of dependencies that are no longer needed.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
    Fixes: [#10800](https://github.com/npm/npm/issues/10800)
  * update-package-json: Update to explicitly include debugging data
    Historically we maintained `_requiredBy` and `_phantomChildren` (and others)
    in `node.package` and then just past them through to disk. As those
    npm now reads (versions) of those attributes directly from `node`, that
    means its no longer maintaining those package attributes.
    But those package attributes are super useful for debugging, so we
    change this to explicitly generate them.
    Also `_requiredBy` is used by the Visual Studio `npm` plugin. Yeah. =/
    We also update sorting to be way more limited, to just fields we know we can
    safely sort.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: Minimize the use of package._bundled
    `_bundled` contains the results of `read-package-tree` on a module that contains
    bundled dependencies. This is `fetch-package-metadata`'s rather unfortunate approach
    to passing this data back to the installer.
    We're changing things to remove it from the `package` object ASAP, which in
    turn let's us avoid removing it (and then putting it back) in the thing that
    writes the package object as `package.json`.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * node: Rename node.package._phantomChildren to node.phantomChildren
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: Rename node.package._location to node.location
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * node: Eliminate _requiredBy entirely
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * save: Eliminate use of _requiredBy
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * deps: Guard failedDependency against requiredBy not existing
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: Rewrite computeLinked to not use _requiredBy
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * diff-trees: Rewrite to use requiredBy instead of _requiredBy
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * is-dev: Rewrite to use requiredBy instead of _requiredBy
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * tar: Rewrite to use requiredBy instead of _requiredBy
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * mutate-into-logical-tree: Rewrite to use requiredBy instead of _requiredBy
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * is-extraneous: Rewrite to use the logical tree
    A package is extraneous if:
    * it is disconnected from the top of the tree, UNLESS
    * There is no top level package.json, OR
    * it was requested as part of the current installation. (That is, `npm install foo` shouldn't show `foo` as extraneous in its summary, but `npm ls` after _should_.)
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: Refactor to explicitly check for top
    We previously checked to see if a module was the root of the tree with
    !node.parent.  This explicitly sets a property (node.isTop), which in turn
    makes code that uses much easier to grok.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * deps: Consistently use userRequired & existing
    Also don't set them at `recalculateMetadata` time.  They're not reset, we
    don't have to recompute them.
    `userRequired` means that the user included this module on the command line
    during this run of npm.
    `existing` means that the module was already on disk when we started.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * deps: Rewrite replaceModule to match by name _or_ path
    Previously replaceModule only matched via name, which was appropriate for
    updating `requires` and children but was not appropriate for `requiredBy`.
    Because `requiredBy` is a list of modules that require this module it can and
    will include modules that exist more than once in the physical tree but the
    current node as a dependency.  As such, those modules need to be uniqued on
    path instead.  We had `userRequired` & `existing` properties on nodes,
    indicating that they were explicitly requested for this install or were on
    already disk when started, respectively.  But we didn't always use them as
    they were added later, sometimes we used huristics based on `_requiredBy`
    which was super ugly.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: loadDeps should skip nodes marked as removed
    You might wonder how it's possible for "removed" nodes to get passed to
    loadDeps in the first place:
    Siblings of a failed dep are unbound from the tree but have a half life, in
    the form of the list of nodes that loadDeps is iterating over.  Modules in
    requiredBy need to be uniqued on path, as it's totally valid to have more
    than one module with the same name requiring the same module.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: Remove failed non-optional deps from tree
    This is specifically referring to failures in finding a matching version.
    It sounds a little weird, because failing non-optional deps are ordinarily
    fatal and would fail out the entire tree, but what this does is ensure that
    transitive non-optional deps of an optional dependency get removed from the
    tree.  Without this, a failure in one dep of an optional dep would
    result in all the other deps of the optional dep still being installed.
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * install: Use removeObsoleteDep when removing from phys tree
    Credit: @iarna
    PR-URL: https://github.com/npm/npm/pull/12775
  * deps: Make removeObsoleteDep remove from phys tree too
    Previously it removed the node from the logical tree, that is,
    requires/requiredBy, but not the physical tree, that is parent/children.
    PR-URL: https://github.com/npm/npm/pull/12775
    Credit: @iarna</pre>
