### PR TITLE
Update "npm" to version 3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
     "github": "1.1.2",
-    "npm": "3.10.0",
+    "npm": "3.10.1",
     "semver": "5.1.0",
     "underscore": "1.8.3",
     "yargs": "4.7.1"


### PR DESCRIPTION
<pre>3.10.1 / 2016-06-18
===================

  * 3.10.1
  * doc: update changelog for 3.10.1
  * test: strip trailing comma
    Standard is unhappy otherwise.
    Credit: @othiym23
    PR-URL: https://github.com/npm/npm/pull/13089
  * tar: restore our version of applyIgnores
    This reverts some of [#11995](https://github.com/npm/npm/issues/11995).  Without this, bundled dependencies don't
    include transitive dependencies.
    Fixes: [#13088](https://github.com/npm/npm/issues/13088)
    Credit: @iarna
    Reviewed-By: @othiym23
    PR-URL: https://github.com/npm/npm/pull/13089
  * ci: clean up tested versions
    Deprioritize 5, remove 0.8, and add 6 for Windows.
    Credit: @othiym23
    Reviewed-By: @iarna
  * tar: revert 4e52cef3d4170c8abab98149666ec599
    If [#5082](https://github.com/npm/npm/issues/5082) is really fixed, a warning is no longer necessary.
    Credit: @othiym23
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/13092
  * fstream@1.0.10
    Ensures that paused streams don't fail to include subsequently added
    entries when resumed.
    Fixes: [#5082](https://github.com/npm/npm/issues/5082)
    Credit: @rvagg
    Reviewed-By: @othiym23
    PR-URL: https://github.com/npm/npm/pull/13092</pre>
