### PR TITLE
Update "eslint" to version 2.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "eslint": "2.13.0",
+    "eslint": "2.13.1",
     "mocha": "2.5.3",
     "sinon": "1.17.4",
     "tmp": "0.0.28"


### PR DESCRIPTION
<pre>2.13.1 / 2016-06-20
===================

  * 2.13.1
  * Build: package.json and changelog update for 2.13.1
  * Fix: wrong baseDir (fixes [#6450](https://github.com/eslint/eslint/issues/6450)) ([#6457](https://github.com/eslint/eslint/issues/6457))
  * Fix: Keep indentation when fixing `padded-blocks` "never" (fixes [#6454](https://github.com/eslint/eslint/issues/6454)) ([#6456](https://github.com/eslint/eslint/issues/6456))
  * Docs: Fix typo in max-params examples ([#6471](https://github.com/eslint/eslint/issues/6471))
    Original meaning inferred from earlier statements in the file, the header for the immediate example, and the code for the rule itself (on line 49).
  * Fix: no-multiple-empty-lines errors when no line breaks (fixes [#6449](https://github.com/eslint/eslint/issues/6449)) ([#6451](https://github.com/eslint/eslint/issues/6451))</pre>
