### PR TITLE
Update "semver" to version 5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "es6-promisify": "4.1.0",
     "github": "1.4.0",
     "npm": "3.10.2",
-    "semver": "5.1.0",
+    "semver": "5.1.1",
     "underscore": "1.8.3",
     "yargs": "4.7.1"
   },


### PR DESCRIPTION
<pre>5.1.1 / 2016-06-23
==================

  * v5.1.1
  * fix [#160](https://github.com/npm/node-semver/issues/160) update cli -h output in readme
  * Fix Backus-Naur "nr" expansion (previous expansion forbade 1 to 9)
  * update travis
  * Fix incorrect comment
    This file has a lot of what-commenting, somewhat by necessity,
    because regular expressions.
    Mostly that's OK, but occasionally it diverges.
    Found while tweeting https://twitter.com/izs/status/672857319739232256</pre>
