### PR TITLE
Update "github" to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
-    "github": "1.4.0",
+    "github": "2.0.0",
     "npm": "3.10.3",
     "semver": "5.1.1",
     "underscore": "1.8.3",


### PR DESCRIPTION
<pre>2.0.0 / 2016-06-26
==================

  * add 2.0.0 info to CHANGELOG
  * add enterprise search indexing endpoint ([#381](https://github.com/mikedeboer/node-github/issues/381))
    resolves [#375](https://github.com/mikedeboer/node-github/issues/375)
  * add source import endpoints ([#380](https://github.com/mikedeboer/node-github/issues/380))
    resolves [#362](https://github.com/mikedeboer/node-github/issues/362)
  * move migration-related endpoints to separate section ([#379](https://github.com/mikedeboer/node-github/issues/379))
  * bump major version
    breaking change: removed getAllPages
  * fix pagination custom headers example
  * remove getAllPages utility method ([#377](https://github.com/mikedeboer/node-github/issues/377))
    I don't feel comfortable keeping this in here as it doesn't really go
    with the other page-related methods. It's easier to just keep it
    consistent and stick to hasNextPage/getNextPage.
    resolves [#350](https://github.com/mikedeboer/node-github/issues/350)
  * Don't require contributors to update apidoc.
  * add note when to run lib/generate.js in readme
  * clarify preview endpoints section in readme
  * add note to run apidoc command in contributing.md</pre>
