### PR TITLE
Update "mocha" to version 3.0.0-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "chai": "3.5.0",
     "eslint": "3.0.0",
-    "mocha": "2.5.3",
+    "mocha": "3.0.0-0",
     "sinon": "1.17.4",
     "tmp": "0.0.28"
   }


### PR DESCRIPTION
<pre>3.0.0-0 / 2016-07-03
====================

  * add "expect" to eslint globals in test/
  * Merge pull request [#2345](https://github.com/mochajs/mocha/issues/2345) from mochajs/appveyor
    adds ability to run tests on windows; adds appveyor to CI; closes [#1813](https://github.com/mochajs/mocha/issues/1813)
  * Merge pull request [#2329](https://github.com/mochajs/mocha/issues/2329) from silentcloud/master
    fix custom comiler file (absolute path) support in windows system
  * FORGOT ONE
  * Get interface name list from collection ([#2343](https://github.com/mochajs/mocha/issues/2343))
    Get interface name list from collection; closes [#2317](https://github.com/mochajs/mocha/issues/2317)
  * run tests on appveyor; closes [#1813](https://github.com/mochajs/mocha/issues/1813)
  * Support test suite on Windows
    Based on work by Tyler Waters <tyler.waters@gmail.com> in [#1814](https://github.com/mochajs/mocha/issues/1814).
    This commit contains the following changes:
    - Add quotation marks to Makefile variables for programs. The variables
    use POSIX-style paths, which cannot be used on Windows to launch a
    program except when quoted. Using double quotation marks instead of
    single since the latter is not available on Windows
    - Use os-tmpdir module to get an acceptable directory for temporary
    usage instead of relying on the POSIX /tmp
    - Use process.execPath as an authoritative path for Node.js executable
    - Detect whether symbolic links are supported on the platform before
    testing. On Windows, creating symlinks can fail since it needs
    additional user permissions
    - Fix hook tests. The tests parse output of the "dot" reporter to
    separate output of individual tests. The "dot" reporter uses "·"
    symbol (U+2024 ONE DOT LEADER) under POSIX environments and "." symbol
    (U+002E FULL STOP) under Windows, which means that having "." in the
    echoed message makes it ambiguous to be parsed in Windows. To fix this
    issue, two separate changes are necessary:
    - Use a dynamically created regular expression to split the tests
    based on the specific dot character used on the platform
    - Replace "." with "-" in echoed messages in fixtures for hook tests
    to avoid ambiguity with the character output by the reporter
    Changes from [#1814](https://github.com/mochajs/mocha/issues/1814) include:
    - Rebasing
    - Use process.execPath as an authoritative path for Node.js executable
    - Avoid external dependencies for child_process.spawn()
    - Detect whether symbol links are supported on the platform before
    testing. On Windows, creating symlinks can fail since it needs
    additional user permissions
    Fixes [#1813](https://github.com/mochajs/mocha/issues/1813).
  * upgrade karma; closes [#2338](https://github.com/mochajs/mocha/issues/2338) ([#2339](https://github.com/mochajs/mocha/issues/2339))
    - reorg `karma.conf.js` a little
    - ensure local SauceLabs tests run
  * Allow skip() in async test context 
    Closes [#2334](https://github.com/mochajs/mocha/issues/2334). PR [#2335](https://github.com/mochajs/mocha/issues/2335).
  * Merge pull request [#2336](https://github.com/mochajs/mocha/issues/2336) from boneskull/issue/2311
    ensures slow() called w/o args does not blast value; closes [#2311](https://github.com/mochajs/mocha/issues/2311)
  * ensures slow() called w/o args does not blast value; closes [#2311](https://github.com/mochajs/mocha/issues/2311)
  * replace regular expression with slice
  * Merge pull request [#2299](https://github.com/mochajs/mocha/issues/2299) from AviVahl/master
    Fix % always 0 in HTML reporter
  * fix custom comiler file (absolute path) support in windows system
  * Ensure browser-entry.js gets published
    Closes [#2323](https://github.com/mochajs/mocha/issues/2323) ([#2324](https://github.com/mochajs/mocha/issues/2324)).
  * Merge pull request [#2307](https://github.com/mochajs/mocha/issues/2307) from jleyba/master
    Fix a small typo in the doc reporter that causes mocha to crash
  * try to fix Gitter/Travis integration, take 2
  * try to fix Gitter/Travis integration
  * Fix a small typo in the doc reporter that causes mocha to crash when a test
    fails.
  * Alternative method to achieve a cleaner syntax.
  * Merge pull request [#2212](https://github.com/mochajs/mocha/issues/2212) from ScottFreeCode/fix/2208
    Correct regex for function source cleaning
  * Merge pull request [#2287](https://github.com/mochajs/mocha/issues/2287) from mochajs/skip-after-regression
    Add failing test: after hook is not run if test skipped in beforeEach; closes [#2286](https://github.com/mochajs/mocha/issues/2286)
  * Nested suites for meta test
  * Clarify nature of meta test
    This should make it possible to understand when just looking at the
    fixture.
  * update pending logic to closely mimic previous behavior
  * Fix % always 0 in HTML reporter
    updateStats() accesses this.total, but this === the global object (window) if not specified explicitly.
    Also added a missing update when all tests end.
  * Correct regex for function source cleaning
    - Treat tabs etc. as spaces.
    - Match function name for removal.
    - Match only non-`)` inside the function parameter list for removal instead of `.`; prevents matching through later in the first line e.g. `function(){ if ([condition]) { ...`.
    - Match 0 or more spaces before } on the end for removal rather than 1 or more.
    - Make the closing } optional for arrow functions with a single-statement body just like the opening {.
    - Add tests for these cases.
  * wip Fix suite being marked as pending when beforeEach skips
  * Add failing test: after hook not run if beforeEach skipped test
    Related to [#2286](https://github.com/mochajs/mocha/issues/2286).</pre>
