### PR TITLE
Update "npm" to version 3.10.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
     "github": "2.1.0",
-    "npm": "3.10.4",
+    "npm": "3.10.5",
     "semver": "5.2.0",
     "underscore": "1.8.3",
     "yargs": "4.7.1"


### PR DESCRIPTION
<pre>3.10.5 / 2016-07-06
===================

  * 3.10.5
  * update AUTHORS
  * mailmap: updates for authors
  * scripts: Update changelog generator to support Fixes URLs
  * doc: update changelog for 3.10.5
  * deps: fix node-gyp@3.4.0
    I do not know what happened, but whatever it is, it went poorly.
    This is a reinstall of node-gyp@3.4.0 which seems to be significantly
    different from the one that was submitted in a PR.
    Credit: @zkat
    Fixes: https://github.com/npm/npm/issues/13256
    PR-URL: https://github.com/npm/npm/pull/13260</pre>
