### PR TITLE
Update "yargs" to version 4.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "npm": "3.10.6",
     "semver": "5.2.0",
     "underscore": "1.8.3",
-    "yargs": "4.7.1"
+    "yargs": "4.8.0"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
<pre>4.8.0 / 2016-07-10
==================

  * chore: cut release
  * docs: switch to the ridiculous appveyor URL you get when you switch project orgs

4.8.0-candidate3 / 2016-07-09
=============================

  * chore(release): 4.8.0
  * fix: ignore invalid package.json during read-pkg-up ([#546](https://github.com/yargs/yargs/issues/546))
  * feat: builder is now optional for a command module ([#545](https://github.com/yargs/yargs/issues/545))
  * fix: lazy-load package.json and cache. get rid of pkg-conf dependency. ([#544](https://github.com/yargs/yargs/issues/544))

4.8.0-candidate2 / 2016-07-09
=============================

  * Merge pull request [#543](https://github.com/yargs/yargs/issues/543) from yargs/greenkeeper-nyc-7.0.0
    Update nyc to version 7.0.0 🚀
  * chore(package): update nyc to version 7.0.0
    https://greenkeeper.io/
  * fix: we now respect the order of _ when applying commands ([#537](https://github.com/yargs/yargs/issues/537))

4.8.0-candidate / 2016-07-04
============================

  * docs: added documentation about commands not inheriting configurations ([#526](https://github.com/yargs/yargs/issues/526))
    * Added documentation about commands not inheriting configurations
    * Moved new text about context, add more details
    * Add anchors for referenced methods
  * feat(command): derive missing command string from module filename ([#527](https://github.com/yargs/yargs/issues/527))
  * fix: drop unused camelcase dependency fixes [#516](https://github.com/yargs/yargs/issues/516) ([#525](https://github.com/yargs/yargs/issues/525))
  * Merge pull request [#524](https://github.com/yargs/yargs/issues/524) from yargs/patch-1
    fix: keep both zh and add zh_CN until yargs@5.x
  * fix: keep both zh and zh_CN until yargs@5.x
  * feat: add .commandDir(dir) to API to apply all command modules from a relative directory ([#494](https://github.com/yargs/yargs/issues/494))
    * feat: add .commandDir() API using require-directory
    * support for nested subcommands with relative dir
    * allow command module to only define command and desc
    * test: add some for commandDir
    * docs: document the .commandDir() method
    * use const where possible based on @maxrimue's review
  * chore(package): update mocha to version 2.5.2
    https://greenkeeper.io/
  * fix: fake a tty in tests, so that we can use the new set-blocking ([#512](https://github.com/yargs/yargs/issues/512))
  * Rename zh.json to zh_CN.json
    This is for simplified Chinese so the correct locale should be zh_CN. For traditional Chinese it should be something like zh_HK or zh_TW.
  * chore(package): update which to version 1.2.9
    https://greenkeeper.io/
  * fix: link build badge to master branch ([#505](https://github.com/yargs/yargs/issues/505))
    link build badge to master branch
  * link build badge to master branch</pre>
