### PR TITLE
Update "semver" to version 5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "es6-promisify": "4.1.0",
     "github": "2.2.0",
     "npm": "3.10.6",
-    "semver": "5.2.0",
+    "semver": "5.3.0",
     "underscore": "1.8.3",
     "yargs": "4.8.0"
   },


### PR DESCRIPTION
<pre>5.3.0 / 2016-07-14
==================

  * v5.3.0
  * style: add some missing semicolons
  * add minSatisfying
  * Fix usage of semver module in docs
    Previously the docs displayed only installing the `semver` module and not going into a node shell or requiring the module before displaying examples.
    I think this update makes it a little clearer that `semver` is a standard node module and it is used internally in `npm`.
    First made change over at https://github.com/npm/npm/pull/10765 but was pointed in the direction of this repo as the source of those docs.</pre>
