### PR TITLE
Update "eslint" to version 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "eslint": "3.0.1",
+    "eslint": "3.1.1",
     "mocha": "3.0.0-1",
     "sinon": "1.17.4",
     "tmp": "0.0.28"


### PR DESCRIPTION
<pre>3.1.1 / 2016-07-18
==================

  * 3.1.1
  * Build: package.json and changelog update for 3.1.1
  * Fix: `eslint:all` causes regression in 3.1.0 (fixes [#6687](https://github.com/eslint/eslint/issues/6687)) ([#6696](https://github.com/eslint/eslint/issues/6696))
  * Fix: Allow named recursive functions (fixes [#6616](https://github.com/eslint/eslint/issues/6616)) ([#6667](https://github.com/eslint/eslint/issues/6667))
  * Fix: `balanced` false positive in `spaced-comment` (fixes [#6689](https://github.com/eslint/eslint/issues/6689)) ([#6692](https://github.com/eslint/eslint/issues/6692))
  * Docs: Add missing brackets from code examples ([#6700](https://github.com/eslint/eslint/issues/6700))
  * Chore: Remove fixable key from multiline-ternary metadata (fixes [#6683](https://github.com/eslint/eslint/issues/6683)) ([#6688](https://github.com/eslint/eslint/issues/6688))
  * Fix: Escape control characters in XML. (fixes [#6673](https://github.com/eslint/eslint/issues/6673)) ([#6672](https://github.com/eslint/eslint/issues/6672))
    When generating XML report with control characters (like "\b" or "\n", they
    are sometimes used in JavaScript object keys and will cause messages.),
    some XML parser like SAX will crash.
    Escape these characters will avoid crashing.

3.1.0 / 2016-07-15
==================

  * 3.1.0
  * Build: package.json and changelog update for 3.1.0
  * Fix: incorrect exitCode when eslint is called with --stdin (fixes [#6677](https://github.com/eslint/eslint/issues/6677)) ([#6682](https://github.com/eslint/eslint/issues/6682))
    Previously exitCode was set at the end of bin/eslint.js but the callback
    executed for --stdin was asynchronous.
    The asynchronous callback was setting exitCode after process.exitCode
    had already been assigned.
    This removes the exitCode variable and just gets each block to set
    process.exitCode directly.
  * Update: make `no-var` fixable (fixes [#6639](https://github.com/eslint/eslint/issues/6639)) ([#6644](https://github.com/eslint/eslint/issues/6644))
    * Update: make `no-var` fixable (fixes [#6639](https://github.com/eslint/eslint/issues/6639))
    * Fix: modify `no-var` not fixing `var` on a case chunk.
    * Chore: add the notes of not-fixable cases.
  * Fix: `no-unused-vars` false positive in loop (fixes [#6646](https://github.com/eslint/eslint/issues/6646)) ([#6649](https://github.com/eslint/eslint/issues/6649))
    * Fix: `no-unused-var` false positive in loop (fixes [#6646](https://github.com/eslint/eslint/issues/6646))
    * Chore: add some private tags to jsdoc comments.
    * Chore: add `isFunctionNode` and `isLoopNode` to ast-utils.
    * Chore: add a test for my mistake.
    https://github.com/eslint/eslint/pull/6649#discussion_r70247810
    * Chore: add tests for `isFunctionNode` and `isLoopNode`
    * Chore: rename `isLoopNode` → `isLoop` and `isFunctionNode` → `isFunction`
  * Update: relax outerIIFEBody definition (fixes [#6613](https://github.com/eslint/eslint/issues/6613)) ([#6653](https://github.com/eslint/eslint/issues/6653))
  * Chore: combine multiple RegEx replaces with one (fixes [#6669](https://github.com/eslint/eslint/issues/6669)) ([#6661](https://github.com/eslint/eslint/issues/6661))
  * Docs: fix typos,wrong path,backticks ([#6663](https://github.com/eslint/eslint/issues/6663))
  * Docs: Add another pre-commit hook to integrations ([#6666](https://github.com/eslint/eslint/issues/6666))
    No problem if you don't accept changes of this nature; I noticed the existing linked pre-commit hook linted the on-disk contents of a staged file rather than just the staged changes. My script only lints the staged changes.
  * Docs: Fix option typo in no-underscore-dangle (Fixes [#6674](https://github.com/eslint/eslint/issues/6674)) ([#6675](https://github.com/eslint/eslint/issues/6675))
  * Chore: add internal rule that validates meta property (fixes [#6383](https://github.com/eslint/eslint/issues/6383)) ([#6608](https://github.com/eslint/eslint/issues/6608))
  * Update: Add `balanced` option to `spaced-comment` (fixes [#4133](https://github.com/eslint/eslint/issues/4133)) ([#6575](https://github.com/eslint/eslint/issues/6575))
  * Docs: fix incorrect example being mark as correct ([#6660](https://github.com/eslint/eslint/issues/6660))
  * Fix: Install required eslint plugin for "standard" guide (fixes [#6656](https://github.com/eslint/eslint/issues/6656)) ([#6657](https://github.com/eslint/eslint/issues/6657))
    `eslint-config-standard` peer depends on `eslint-plugin-promise`, so
    let's install that for users.
  * New: `endLine` and `endColumn` of the lint result. (refs [#3307](https://github.com/eslint/eslint/issues/3307)) ([#6640](https://github.com/eslint/eslint/issues/6640))
  * Docs: Small tweaks to CLI documentation (fixes [#6627](https://github.com/eslint/eslint/issues/6627)) ([#6642](https://github.com/eslint/eslint/issues/6642))
  * Docs: Added examples and structure to `padded-blocks` (fixes [#6628](https://github.com/eslint/eslint/issues/6628)) ([#6643](https://github.com/eslint/eslint/issues/6643))
  * Docs: Typo ([#6650](https://github.com/eslint/eslint/issues/6650))
  * Docs: Correct a term in max-len.md (fixes [#6637](https://github.com/eslint/eslint/issues/6637)) ([#6641](https://github.com/eslint/eslint/issues/6641))
  * Fix: Warning behavior for executeOnText (fixes [#6611](https://github.com/eslint/eslint/issues/6611)) ([#6632](https://github.com/eslint/eslint/issues/6632))
  * Chore: Enable preferType in valid-jsdoc (refs [#5188](https://github.com/eslint/eslint/issues/5188)) ([#6634](https://github.com/eslint/eslint/issues/6634))
  * Fix: Use default assertion messages (fixes [#6532](https://github.com/eslint/eslint/issues/6532)) ([#6615](https://github.com/eslint/eslint/issues/6615))
  * Fix: Do not throw exception if baseConfig is provided (fixes [#6605](https://github.com/eslint/eslint/issues/6605)) ([#6625](https://github.com/eslint/eslint/issues/6625))
  * Upgrade: mock-fs to 3.10, fixes for Node 6.3 (fixes [#6621](https://github.com/eslint/eslint/issues/6621)) ([#6624](https://github.com/eslint/eslint/issues/6624))
  * New: multiline-ternary rule (fixes [#6066](https://github.com/eslint/eslint/issues/6066)) ([#6590](https://github.com/eslint/eslint/issues/6590))
  * Update: Adding new `key-spacing` option (fixes [#5613](https://github.com/eslint/eslint/issues/5613)) ([#5907](https://github.com/eslint/eslint/issues/5907))
    `align` is now available as a stand-alone configurations.
    This allows specifying how spacing should work when aligning
    values in a group.
  * Docs: Remove reference from 3.0.0 migration guide (refs [#6605](https://github.com/eslint/eslint/issues/6605)) ([#6618](https://github.com/eslint/eslint/issues/6618))
  * Docs: Removed non-existing resource ([#6609](https://github.com/eslint/eslint/issues/6609))
  * Docs: Note that PR requires ACCEPTED issue (refs [#6568](https://github.com/eslint/eslint/issues/6568)) ([#6604](https://github.com/eslint/eslint/issues/6604))</pre>
