### PR TITLE
Update "github" to version 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
-    "github": "2.2.0",
+    "github": "2.4.0",
     "npm": "3.10.6",
     "semver": "5.3.0",
     "underscore": "1.8.3",


### PR DESCRIPTION
<pre>2.4.0 / 2016-07-28
==================

  * bump to 2.4.0 and update changelog
  * small adjustment to renderMarkdown apidoc
  * Merge branch 'add-render-markdown-example' into pull-request-403
  * add render markdown example
  * Avoid parsing non json data
    At least two API calls (markdown and markdown raw), return data that is not JSON. 
    We can check the content-type header and avoid parsing this data.
  * small readme formatting change
  * add preview apis section to readme ([#402](https://github.com/mikedeboer/node-github/issues/402))
  * add github pages preview stuff ([#401](https://github.com/mikedeboer/node-github/issues/401))

2.3.0 / 2016-07-24
==================

  * bump to 2.3.0 and update changelog
  * add wyandotte to list of preview header vals
  * issue locking/unlocking is official
    https://developer.github.com/changes/2016-06-22-issue-locking-api-is-now-official/
  * multiple assignees api is now official
    Remove preview period notices and associated preview request media
    header.
    https://developer.github.com/changes/2016-07-12-ending-multiple-assignees-preview-period/
  * add protected branch api endpoints ([#398](https://github.com/mikedeboer/node-github/issues/398))
    resolves [#391](https://github.com/mikedeboer/node-github/issues/391)
  * destroy socket on timeout ([#395](https://github.com/mikedeboer/node-github/issues/395))
    resolves [#292](https://github.com/mikedeboer/node-github/issues/292)</pre>
