### PR TITLE
Update "mocha" to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "chai": "3.5.0",
     "eslint": "3.2.0",
-    "mocha": "3.0.0-1",
+    "mocha": "3.0.0",
     "sinon": "1.17.5",
     "tmp": "0.0.28"
   }


### PR DESCRIPTION
<pre>3.0.0 / 2016-08-01
==================

  * Release v3.0.0
  * rebuild mocha.js
  * fix bad merge of karma.conf.js
  * add note about spec reporter to CHANGELOG.md [ci skip]
  * fixed typo in mocha.css introduced by 185c0d902e272216232630fe4e2577268456dd9a [ci skip]
  * Remove carriage return before each test line in spec reporter. Served no purpose
  * add "logo" field to package.json [ci skip]
  * fix incorrect executable name with new version of commander
    - yuck
  * add bower.json to published package for npmcdn support [ci skip]
  * fix broken/wrong URLs in CHANGELOG.md [ci skip]
  * Release v3.0.0-2
  * add browser-stdout to dependencies
    - addresses issue wherein mocha possibly cannot be browserified with a production install
  * update CHANGELOG [ci skip]
  * let child suites run if parent is exclusive; closes [#2378](https://github.com/mochajs/mocha/issues/2378) ([#2387](https://github.com/mochajs/mocha/issues/2387))
    - includes some more refactoring of interface code into `lib/interfaces/common.js` for DRY (still more work to be done here)
    - unfortunately said refactoring contains hellish logic which addresses this issue (someone should make a flowchart of this for lolz)
    - original PR did not address `exports` interface; this doesn't either
    - may need more coverage against `qunit` interface
  * Upgrade eslint package to 2.13 version ([#2389](https://github.com/mochajs/mocha/issues/2389))
    Rules space-after-keywords and space-return-throw-case merged into keyword-spacing
  * markdown fixes for CHANGELOG.md [ci skip]
  * fix bad reference to to-iso-string in test
  * suppress warning about .eslintignore when running ESLint
  * copy to-iso-string; closes [#2378](https://github.com/mochajs/mocha/issues/2378)
  * added changes to CHANGELOG.md [ci skip]
  * tweak wording on "overspecification" exception
  * wip CHANGELOG update
  * display executed commands in Makefile for debugging
  * fix mocha.js target
    - remove non-existent files (`SUPPORT`)
    - add `browser-entry.js`
  * remove references to test-outputs/ dir, which is unused
  * Release v3.0.0-1
  * add missing "homepage" to package.json [ci skip]
  * rebuild
  * change repo url to https scheme instead of git
  * remove redundant "licenses" field and deprecated "engineStrict" from package.json
  * fix some modules which should be ignored in karma config
  * drop jsoncov/htmlcov reporters; closes [#2356](https://github.com/mochajs/mocha/issues/2356)
  * update woefully out-of-date bower.json [ci skip]
  * add production "sanity" check to Travis CI
  * update contributors [ci skip]
    - used [update-contributors](https://www.npmjs.com/package/update-contributors), sorted ascending case-insensitive; removed dupes
  * revert changes that broke a regression test fixture
  * drop component support; closes [#2269](https://github.com/mochajs/mocha/issues/2269)
  * Release v3.0.0-0
  * build for prerelease
  * increase integration test timeouts across-the-board for AppVeyor
  * increase timeout in test/color.js for AppVeyor
  * ensure bundle dir is set before trying to write somewhere in Karma
  * caching doesn't work; forget it
  * split up matrix a bit
  * downgrade lodash.create to v3 for ES3
  * update travis.yml and karma to upload karma bundles to S3 for debugging
  * fix .PHONY [ci skip]
  * feat(runner): fix '.only()' exclusive feature, [#1481](https://github.com/mochajs/mocha/issues/1481)
    This PR fix [#1481](https://github.com/mochajs/mocha/issues/1481), and also extends the .only() behaviour.
    (i.e: it's not use grep anymore, support suite, test-case or both, add
    the ability to run multiple .only)
  * fix wonky lookupFiles test; closes [#2347](https://github.com/mochajs/mocha/issues/2347)
  * fixup merge for pr [#1809](https://github.com/mochajs/mocha/issues/1809)
  * fix(Suite/Test): untitled suite/test-case [#1632](https://github.com/mochajs/mocha/issues/1632)
    Throw a user-friendly error when the suite title or the test-case title
    isn't provided.
  * upgrade diff back to original
  * remove dupe mkdirp dep
  * fix integration tests with changes to dot reporter
  * Use more visually-distinctive characters on the 'dot' reporter
  * downgrade diff for ES3
  * generate build artifacts from bundled test files
  * remove unneeded os-tmpdir
  * fail fast in CI; try to cache phantom binary; enable artifact addon
  * rename *.jade => .pug
  * upgrade all possible deps; use pug instead of jade
  * drop v0.8x support
  * fix test for my sneaky change to timeout()
  * feature(mocha/grep): improve grep - issue [#808](https://github.com/mochajs/mocha/issues/808)
    Add the ability to pass grep as a regexp-like string. (query in the
    browser or flag in the cli).
    This improvement gives you pass a regexp that including a flag, and
    solved [#808](https://github.com/mochajs/mocha/issues/808) as well.
  * Throw an exception when timeout too large.
    closes [#1644](https://github.com/mochajs/mocha/issues/1644)
  * Fail when test resolution method is overspecified
    Users may register `Runnable`s as asynchronous in one of two ways:
    - Via callback (by defining the body function to have an arity of one)
    - Via promise (by returning a Promise object from the body function)
    When both a callback function is specified *and* a Promise object is
    returned, the `Runnable`'s resolution condition is ambiguous.
    Practically speaking, users are most likely to make this mistake as they
    transition between asynchronous styles.
    Currently, Mocha silently prefers the callback amd ignores the Promise
    object. Update the implementation of the `Runnable` class to fail
    immediately when the test resolution method is over-specified in this
    way.
  * Require npm version which supports `^` specifier
    https://travis-ci.org/mochajs/mocha/jobs/38422941
    The only problem in this error is that npm v1.2 doesn’t support `^`
    version specifier. It's not the problem of Node v0.8 itself.
    So I updated the installation command to install the latest version of
    npm, before installing the dependencies of mocha.
  * Update glob to 4.0.6
  * add json3 to json-cov and json-stream reporters
  * fix toISOString and utils tests for IE7
  * Fix missing methods/globals in IE7, IE8 environments
  * console.err -> console.error (.travis.yml)
  * update karma config
    - more clarity around what's happening when it's happening
    - attempting to ensure PR builds from `mochajs/mocha` branches will run SauceLabs; previously only the "branch" build was running

3.0.0-2 / 2016-07-26
====================

  * update some gitter notifications (again)
  * Update syntax for "border-radius" and "box-shadow", added vendor prefixes for calc() ([#2367](https://github.com/mochajs/mocha/issues/2367))
    * Update syntax for "border-radius" and "box-shadow", added vendor prefixes for calc()
    * mocha.css: Reverted whitespace differences
  * don't truncate message-list Error in Base.list(); closes [#2361](https://github.com/mochajs/mocha/issues/2361) ([#2365](https://github.com/mochajs/mocha/issues/2365))
  * Add --preserve-symlinks flag for node ([#2364](https://github.com/mochajs/mocha/issues/2364))</pre>
