### PR TITLE
Update "npm" to version 3.10.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
     "github": "2.4.1",
-    "npm": "3.10.6",
+    "npm": "3.10.7",
     "semver": "5.3.0",
     "underscore": "1.8.3",
     "yargs": "4.8.1"


### PR DESCRIPTION
<pre>3.10.7 / 2016-08-12
===================

  * 3.10.7
  * update AUTHORS
  * mailmap: update with latest contributors
  * doc: update changelog for 3.10.7
  * scripts: update changelog generator
  * lodash.clonedeep@4.4.1
    Credit: @jdalton
  * lodash.without@4.3.0
    Credit: @jdalton
  * lodash.union@4.5.0
    Credit: @jdalton
  * lodash.uniq@4.4.0
    Credit: @jdalton
  * lodash.without@4.2.0
    Credit: @jdalton
  * rimraf@2.5.4
    Clarify assertions: cb is required, options are not
    Fixes: https://github.com/isaacs/rimraf/issues/111
    Credit: @isaacs
  * minimatch@3.0.3
    Update minimatch to 3.0.3 to get fix for ReDOS vuln.
    Fixes: https://github.com/npm/npm/issues/13387
    PR-URL: https://github.com/npm/npm/pull/13415
    Credit: @isaacs
  * tap@6.3.2
  * marked@0.3.6
  * request@2.74.0
    Update request library to at least 2.73 to fix:
    npm install failed - Cannot read property 'emit' of null
    Fixes: [#9984](https://github.com/npm/npm/issues/9984)
    PR-URL: https://github.com/npm/npm/pull/13432
    Credit: @zarenner
    Reviewed-By: @iarna
  * graceful-fs@4.1.5
    graceful-fs had a bug fix, https://github.com/isaacs/node-graceful-fs/pull/71,
    which would fix the problem in Node.js https://github.com/nodejs/node/pull/7846
    PR-URL: https://github.com/npm/npm/pull/13497
    Credit: @thefourtheye
    Reviewed-By: @iarna
  * error: Correct url in an error message of typeerror
    Credit: @watilde
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/13626
  * shrinkwrap: Improve detection of pkgs req'd by top level dev deps
    Specifically, we now don't blow the stack on dev deps that have cycles.
    Fixes: [#13327](https://github.com/npm/npm/issues/13327)
  * install: fix hiccup that caused a conflict
    Basically, there was some duck typing in `resolveWithNewModule`
    in situations where the function got a `package.json` from `npa`,
    rather than the internal request object.
    The issue reared its head because of a package that had `type`
    in its `package.json`, which confused the duck typing.
    Instead, the special case was inlined into (afaict) the only
    place where it was actually triggered from.
    Fixes: https://github.com/npm/npm/issues/11398
    Credit: @zkat
    PR-URL: https://github.com/npm/npm/pull/13635
    Reviewed-By: @iarna
  * doc: Clarify that npm@2 is required for scoped packages
    PR-URL: https://github.com/npm/npm/pull/10167
    Credit: @danpaz
    Reviewed-By: @othiym23
  * config: pretend login is a toplevel command
    The `login` command has long been an alias for `adduser`.
    At the same time, there is an expectation not just of that
    particular word being something to look for, but of there being
    clear symmetry with `logout`.
    So it was a bit confusing when `login` didn't show up in
    `npm help` on a technicality. This seems like an acceptable
    exception to the rule that says "no aliases in `npm help`".
    Fixes: https://github.com/npm/npm/issues/13581
    PR-URL: https://github.com/npm/npm/pull/13580
    Credit: @zkat
    Reviewed-By: @iarna
  * doc: explain difference between `version` and `preversion` scripts
    PR-URL: https://github.com/npm/npm/pull/13349
    Credit: @christophehurpeau
    ReviewedBy: @iarna
  * update-linked: Only warn about symlink update if version number differs
    The update-linked action outputs a warning that it needs to update the
    linked package, but can't, There is no need for the package to be updated if
    it is already at the correct version.  This change does a check before
    logging the warning.
    PR-URL: https://github.com/npm/npm/pull/12893
    Credit: @DaveEmmerson
    Reviewed-By: @iarna
  * inflate-shrinkwrap: Determine equivalency of git deps correctly
    Prevent inflateShrinkwrap function from relying on a package version
    for git dependencies. That was the cause of two problems:
    1. When node_modules dir contains an outdated git dependency,
    it won't be updated during npm install.
    2. npm shrinkwrap command fails.
    Fixes: https://github.com/npm/npm/issues/12718.
    Credit: @kossnocorp
    PR-URL: https://github.com/npm/npm/pull/12770
    Reviewed-By: @iarna
  * install: add GIT_EXEC_PATH to git env whitelist
    Fixes: [#13353](https://github.com/npm/npm/issues/13353)
    PR-URL: https://github.com/npm/npm/pull/13358
    Credit: @mhart
    Reviewed-By: @othiym23
  * readme: remove 0.8 from readme as well
    Credit: @watilde
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/13319
  * install: Run top level preinstall before installing dependencies
    Credit: @palmerj3
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/13259
  * fstream-npm@1.1.1
    Fixes bug with inclusion of scoped bundledDependencies.
    Fixes: https://github.com/npm/npm/issues/8614
    PR-URL: https://github.com/npm/fstream-npm/pull/22
    Credit: @forivall
    Reviewed-By: @zkat
  * tar: include scoped packages in bundledDeps
    PR-URL: https://github.com/npm/npm/pull/13438
    Fixes: https://github.com/npm/npm/issues/8614
    Credit: @forivall
    Reviewed-By: @iarna
    Reviewed-By: @zkat
  * test: added basic bundledDeps tests
  * test: separate the remaining network tests
    PR-URL: https://github.com/npm/npm/pull/13397
    Credit: @iarna
    Reviewed-By: @othiym23
  * test: Stop using network with invalid-dep-version-filtering test
    PR-URL: https://github.com/npm/npm/pull/13397
    Credit: @iarna
    Reviewed-By: @othiym23
  * test: Stop using network in 404-private-registry test
    PR-URL: https://github.com/npm/npm/pull/13397
    Credit: @iarna
    Reviewed-By: @othiym23
  * test: Stop using network in 404-private-registry-scoped test
    PR-URL: https://github.com/npm/npm/pull/13397
    Credit: @iarna
    Reviewed-By: @othiym23
  * test: Stop update-symlink test from hitting network
    PR-URL: https://github.com/npm/npm/pull/13397
    Credit: @iarna
    Reviewed-By: @othiym23</pre>
