### PR TITLE
Update "yargs" to version 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "npm": "3.10.7",
     "semver": "5.3.0",
     "underscore": "1.8.3",
-    "yargs": "4.8.1"
+    "yargs": "5.0.0"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
<pre>5.0.0 / 2016-08-16
==================

  * Merge pull request [#594](https://github.com/yargs/yargs/issues/594) from yargs/greenkeeper-cpr-2.0.0
    Update cpr to version 2.0.0 🚀
  * chore(package): update cpr to version 2.0.0
    https://greenkeeper.io/

5.0.0-candidate / 2016-08-14
============================

  * chore(release): 5.0.0
  * tests: remove osx from CI, until Travis fixes OSX servers
  * docs: added gitter badge ([#593](https://github.com/yargs/yargs/issues/593))
  * chore(package): update string-width to version 1.0.2 ([#591](https://github.com/yargs/yargs/issues/591))
    https://greenkeeper.io/
  * Merge pull request [#590](https://github.com/yargs/yargs/issues/590) from yargs/greenkeeper-nyc-8.1.0
    Update nyc to version 8.1.0 🚀
  * chore(package): update nyc to version 8.1.0
    https://greenkeeper.io/
  * perf: defer requiring most external libs until needed ([#584](https://github.com/yargs/yargs/issues/584))
    * perf: defer requiring most external libs until needed
    * perf: do not require string-width more than once
  * feat: adds recommendCommands() for command suggestions ([#580](https://github.com/yargs/yargs/issues/580))
    * feat: provide suggestions if unknown command is called
    * add y18n locale support for command recommendations
    * fix tests for command recommendations
    * make german translation more personal
    * update .recommendCommands() following @nexdrew's review
    * add more tests for .recommendCommands()
    * add didyoumean threshold
    * mention in readme no parameter is required for .recommendCommands()
    * fix silly mistake
    * feat: adds recommendCommands()
    * fix: implement @nexdrew's suggestion; sort commands so that we recommend longest first
  * chore(package): update lodash.assign to version 4.2.0 ([#587](https://github.com/yargs/yargs/issues/587))
    https://greenkeeper.io/
  * chore(package): update yargs-parser to version 3.2.0 ([#588](https://github.com/yargs/yargs/issues/588))
    https://greenkeeper.io/
  * feat: add coerce api ([#586](https://github.com/yargs/yargs/issues/586))
    * feat: add coerce api
    * support coercion of positional args in command
    * docs: add .coerce() method
  * feat: apply default builder to command() and apply fail() handlers globally ([#583](https://github.com/yargs/yargs/issues/583))
    BREAKING CHANGE: fail is now applied globally.
    BREAKING CHANGE: we now default to an empty builder function when command is executed with no builder.
  * feat: interpret demand() numbers as relative to executing command ([#582](https://github.com/yargs/yargs/issues/582))
  * feat: update yargs-parser to version 3.1.0 ([#581](https://github.com/yargs/yargs/issues/581))
    BREAKING CHANGE: yargs-parser now better handles negative integer values, at the cost of handling numeric option names, e.g., -1 hello
  * feat: apply .env() globally ([#553](https://github.com/yargs/yargs/issues/553))
  * fix: remove deprecated zh.json ([#578](https://github.com/yargs/yargs/issues/578))
  * fix(default): Remove undocumented alias of default() ([#469](https://github.com/yargs/yargs/issues/469))
    BREAKING CHANGE:
    removed undocumented `defaults` alias for `default`.
  * feat(command): builder function no longer needs to return the yargs instance ([#549](https://github.com/yargs/yargs/issues/549))
    BREAKING CHANG:
    changes the behavior of a builder function, so that the updated yargs object no longer needs to be returned.
  * feat: .help() API can now enable implicit help command ([#574](https://github.com/yargs/yargs/issues/574))
    BREAKING CHANGE:
    introduces a default `help` command which outputs help, as an alternative to a help flag.
  * Merge pull request [#575](https://github.com/yargs/yargs/issues/575) from yargs/greenkeeper-mocha-3.0.1
    mocha@3.0.1 breaks build 🚨
  * chore(package): update mocha to version 3.0.1
    https://greenkeeper.io/
  * Merge pull request [#572](https://github.com/yargs/yargs/issues/572) from yargs/greenkeeper-mocha-3.0.0
    Update mocha to version 3.0.0 🚀
  * chore(package): update mocha to version 3.0.0
    https://greenkeeper.io/
  * docs: 'yargs is here to help you example' to demand both command and argument under the same demand ([#567](https://github.com/yargs/yargs/issues/567))</pre>
