### PR TITLE
Update "npm" to version 3.10.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
     "github": "2.6.0",
-    "npm": "3.10.7",
+    "npm": "3.10.8",
     "semver": "5.3.0",
     "underscore": "1.8.3",
     "yargs": "4.8.1"


### PR DESCRIPTION
<pre>3.10.8 / 2016-09-09
===================

  * 3.10.8
  * update AUTHORS
  * doc: update changelog for 3.10.8
  * doc: clarify how config files are configured
    PR-URL: https://github.com/npm/npm/pull/13911
    Credit: @othiym23
    Reviewed-By: @zkat
  * doc: update semver docs for semver@5.3.0
    Credit: @zkat
  * write-file-atomic@1.2.0
    * Preserve chmod and chown from the overwritten file
    Credit: @iarna
  * which@1.2.11
    Credit: @isaacs
  * semver@5.3.0
    * add
    * add
    * remove test files from distribution
    * doc and style updates
    Credit: @isaacs
  * retry@0.10.0
    Credit: @tim-kos
  * readable-stream@2.1.5
    Credit: @calvinmetcalf
  * once@1.4.0
    Added `once.strict`
    Credit: @zkochan
  * npmlog@4.0.0
    Allows creating log levels that are empty strings or 0
    PR-URL: https://github.com/npm/npmlog/pull/34
    Credit: @rwaldron
  * npm-registry-client@7.2.1
    * Fix EventEmitter warning spam from error handlers on socket
    * Add support for streaming request bodies
    * dependency updates
    * docs
    Credit: @othiym23
    Fixes: https://github.com/npm/npm/issues/13656
  * inherits@2.0.3
    Credit: @isaacs
  * lodash.without@4.4.0
    Credit: @jdalton
  * lodash.uniq@4.5.0
    Credit: @jdalton
  * lodash.union@4.6.0
    Credit: @jdalton
  * lodash.clonedeep@4.5.0
    Credit: @jdalton
  * graceful-fs@4.1.6
    Fix issue with number of arguments of chmod/chown cb
    Credit: @francescoinfante
  * glob@7.0.6
    stop throwing on `glob.hasMagic("")`
    Credit: @isaacs
  * doc: per-user config file isn't hardcoded
    Document that the per-user config file respects the `$NPM_CONFIG_USERCONFIG` env var, defaulting to ~/.npmrc
    PR-URL: https://github.com/npm/npm/pull/13493
    Credit: @jasonkarns
    Reviewed-By: @iarna
  * lifecycle: split node_module path parts properly
    In lifecycle scripts, any `node_modules/.bin` existing in the heirarchy
    should be turned into an entry in the PATH environment variable.
    However, prior to this commit, it was splitting based on the string
    `node_modules`, rather than restricting it to only path portions like
    `/node_modules/` or `\node_modules\`.  So, a path containing an entry
    like `my_node_modules` would be improperly split.
    Fixes: [#13456](https://github.com/npm/npm/issues/13456)
    PR-URL: https://github.com/npm/npm/pull/13518
    Credit: @isaacs
    Reviewed-By: @zkat
  * shrinkwrap: save-dev updates shrinkwrap file
    Running 'npm install --save-dev' will update shrinkwrap file, but only
    if there already are any dev dependencies in this file.
    Fixes: [#11735](https://github.com/npm/npm/issues/11735)
    PR-URL: https://github.com/npm/npm/pull/13860
    Credit: @szimek
    Reviewed-By: @iarna
  * doc: explain how to set node env in bin scripts
    Fixes: [#12438](https://github.com/npm/npm/issues/12438)
    Credit: @mxstbr
    Reviewed-By: @zkat
    PR-URL: https://github.com/npm/npm/pull/13598
  * doc: add details about npmrc comments
    I found that information about commenting lines in a `.npmrc` file was lacking from the official documentation. I've updated the doc to reflect currently supported ways to commenting lines in the npm config file as found through reading other sources and through experimentation with different ways of adding comments.
    PR-URL: https://github.com/npm/npm/pull/13655
    Credit: @mdjasper
    Reviewed-By: @zkat
  * doc: Minor grammar fix in docs for npm scripts
    PR-URL: https://github.com/npm/npm/pull/13682
    Credit: @Ajedi32
    Reviewed-By: @zkat
  * doc: npm link will link bin of project.
    This documents the fact that `npm link` will link
    the files specified in the `bin` field of `package.json`
    to `{prefix}/bin/{name}`.
    PR-URL: https://github.com/npm/npm/pull/13717
    Credit: @legodude17
    Reviewed-By: @zkat
  * tar: ignore *.orig files
    Credit: @boneskull
    PR-URL: https://github.com/npm/npm/pull/13708
    Reviewed-By: @zkat
  * fstream-npm@1.2.0
    PR-URL: https://github.com/npm/fstream-npm/pull/23
    Ref: https://github.com/npm/npm/pull/13708
    Credit: @zkat
    Reviewed-By: @othiym23
  * install/actions: Check installability of modules from shrinkwrap
    Modules that came into the tree via shrinkwrap won't have had this
    determined in advance so we check here and take advantage of the
    optional rollback semantics to skip them.
    Plus if it was a regular dependency we can just fail out now instead of
    trying and failing to install the dep.
    Fixes: [#13394](https://github.com/npm/npm/issues/13394)
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * report-optional-failure: Improve information on error object
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * install/actions: Use standard optional error reporting
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * install/deps: Stop weird call-back-to-self in resolveWithNewModule
    We were doing a weird thing where we used a package.json field _installable_
    to check to see if we'd checked for platform compatibility, and if not did
    so.  But this was the only place that was ever done so there was no reason to
    implement it in such an obfuscated manner.
    Instead it now just directly checks and then records that its done so on the
    node object with `knownInstallable`.  This is useful to know because modules
    expanded via shrinkwrap don't go through this– `inflateShrinkwrap` does not
    currently have any rollback semantics and so checking this sort of thing there
    is unhelpful.
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * install/deps: Factor optional failure reporting into its own module
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * install/deps: Factor flatNameFromTree out of install/deps
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * install/actions: Use error formatter for reporting optional dep failures
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * error-message: Improve error reporting for opt deps
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * error-message: Improve error message for unsupported platforms
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * install: Include warning details at verbose log level
    PR-URL: https://github.com/npm/npm/pull/13692/
    Credit: @iarna
    Reviewed-By: @zkat
  * fetch-package-metdata: Consistently set code on ETARGET errors
    Credit: @iarna
  * scripts: Fix fixture creation/cleanup in maketest
    Credit: @iarna
  * scripts: Add helper for generating test skeletons
    Credit: @iarna
  * shrinkwrap: Record if a dependency is optional to shrinkwrap
    Credit: @bengl
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/10073
  * shrinkwrap: Record if dep is dev-only and honor the annotation
    Credit: @bengl
    Reviewed-By: @iarna
    PR-URL: https://github.com/npm/npm/pull/10073</pre>
