### PR TITLE
Update "github" to version 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
-    "github": "2.6.0",
+    "github": "3.1.0",
     "npm": "3.10.8",
     "semver": "5.3.0",
     "underscore": "1.8.3",


### PR DESCRIPTION
<pre>3.1.0 / 2016-09-16
==================

  * bump to 3.1.0 and update changelog
  * add projects preview api ([#418](https://github.com/mikedeboer/node-github/issues/418))
  * add endpoint to get specific pages build

3.0.0 / 2016-09-05
==================

  * bump to 3.0.0
    breaking change: issues.updateLabel
  * fix updateLabel endpoint ([#416](https://github.com/mikedeboer/node-github/issues/416))
    Rename first name param to oldname and add new name param.
    Add updateLabel example.
  * add example with both get-user-orgs endpoints
    There are two ways to list a user's orgs. One for the authenticated user
    and one for any user given the username.
  * change descriptions for list-user-org endpoints ([#414](https://github.com/mikedeboer/node-github/issues/414))
    Avoid any confusion regarding [#413](https://github.com/mikedeboer/node-github/issues/413) between users.getOrgs and
    orgs.getForUser.</pre>
