### PR TITLE
Update "github" to version 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "changelog": "^1.0.7",
     "es6-promisify": "4.1.0",
-    "github": "3.1.0",
+    "github": "3.1.1",
     "npm": "3.10.8",
     "semver": "5.3.0",
     "underscore": "1.8.3",


### PR DESCRIPTION
<pre>3.1.1 / 2016-09-24
==================

  * bump to 3.1.1 and update changelog
  * fix permission param ([#422](https://github.com/mikedeboer/node-github/issues/422))
    The permission param was global in the routes.json but should really be
    on a per-endpoint basis since it's slightly different for each. Also
    change the add-collaborator default value to push to reflect a change in
    the github api doc. The change applies to the following endpoints:
    add-collaborator
    update-invite
    add-team-repo
  * add add-collaborator example</pre>
