### PR TITLE
Update "eslint" to version 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "eslint": "3.5.0",
+    "eslint": "3.6.0",
     "mocha": "3.0.2",
     "sinon": "1.17.6",
     "tmp": "0.0.29"


### PR DESCRIPTION
<pre>3.6.0 / 2016-09-23
==================

  * 3.6.0
  * Build: package.json and changelog update for 3.6.0
  * Update: add fixer for `strict` (fixes [#6668](https://github.com/eslint/eslint/issues/6668)) ([#7198](https://github.com/eslint/eslint/issues/7198))
  * Docs: Update ecmaVersion instructions ([#7195](https://github.com/eslint/eslint/issues/7195))
  * Update: Allow `space-unary-ops` to handle await expressions ([#7174](https://github.com/eslint/eslint/issues/7174))
    (refs [#7101](https://github.com/eslint/eslint/issues/7101))
  * Update: add fixer for `prefer-template` (fixes [#6978](https://github.com/eslint/eslint/issues/6978)) ([#7165](https://github.com/eslint/eslint/issues/7165))
  * Update: `no-extra-parens` supports async/await (refs [#7101](https://github.com/eslint/eslint/issues/7101)) ([#7178](https://github.com/eslint/eslint/issues/7178))
  * Fix: Handle number literals correctly in `no-whitespace-before-property` ([#7185](https://github.com/eslint/eslint/issues/7185))
  * Update: `keyword-spacing` supports async/await (refs [#7101](https://github.com/eslint/eslint/issues/7101)) ([#7179](https://github.com/eslint/eslint/issues/7179))
  * Update: Allow template string in `valid-typeof` comparison (fixes [#7166](https://github.com/eslint/eslint/issues/7166)) ([#7168](https://github.com/eslint/eslint/issues/7168))
  * Fix: Don't report async/generator callbacks in `array-callback-return` ([#7172](https://github.com/eslint/eslint/issues/7172))
    (refs [#7101](https://github.com/eslint/eslint/issues/7101))
  * Fix: Handle async functions correctly in `prefer-arrow-callback` fixer ([#7173](https://github.com/eslint/eslint/issues/7173))
    (refs [#7101](https://github.com/eslint/eslint/issues/7101))
  * Fix: Handle await expressions correctly in `no-unused-expressions` ([#7175](https://github.com/eslint/eslint/issues/7175))
    (refs [#7101](https://github.com/eslint/eslint/issues/7101))
  * Update: Ensure `arrow-parens` handles async arrow functions correctly ([#7176](https://github.com/eslint/eslint/issues/7176))
    (refs [#7101](https://github.com/eslint/eslint/issues/7101))
  * Chore: add tests for `generator-star-spacing` and async (refs [#7101](https://github.com/eslint/eslint/issues/7101)) ([#7182](https://github.com/eslint/eslint/issues/7182))
  * Update: Let `no-restricted-properties` check destructuring (fixes [#7147](https://github.com/eslint/eslint/issues/7147)) ([#7151](https://github.com/eslint/eslint/issues/7151))
  * Fix: valid-jsdoc does not throw on FieldType without value (fixes [#7184](https://github.com/eslint/eslint/issues/7184)) ([#7187](https://github.com/eslint/eslint/issues/7187))
  * Docs: Update process for evaluating proposals (fixes [#7156](https://github.com/eslint/eslint/issues/7156)) ([#7183](https://github.com/eslint/eslint/issues/7183))
  * Update: Make `no-restricted-properties` more flexible (fixes [#7137](https://github.com/eslint/eslint/issues/7137)) ([#7139](https://github.com/eslint/eslint/issues/7139))
  * Update: fix `quotes` rule's false negative (fixes [#7084](https://github.com/eslint/eslint/issues/7084)) ([#7141](https://github.com/eslint/eslint/issues/7141))
  * Update: fix `no-unused-vars` false negative (fixes [#7124](https://github.com/eslint/eslint/issues/7124)) ([#7143](https://github.com/eslint/eslint/issues/7143))
  * Fix: Report columns for `eol-last` correctly (fixes [#7136](https://github.com/eslint/eslint/issues/7136)) ([#7149](https://github.com/eslint/eslint/issues/7149))
  * Update: add fixer for quote-props (fixes [#6996](https://github.com/eslint/eslint/issues/6996)) ([#7095](https://github.com/eslint/eslint/issues/7095))
  * Upgrade: espree to 3.2.0, remove tests with SyntaxErrors (fixes [#7169](https://github.com/eslint/eslint/issues/7169)) ([#7170](https://github.com/eslint/eslint/issues/7170))
  * Fix: `max-len`: `ignoreTemplateLiterals`: handle 3+ lines (fixes [#7125](https://github.com/eslint/eslint/issues/7125)) ([#7138](https://github.com/eslint/eslint/issues/7138))
  * Docs: Update rule descriptions (fixes [#5912](https://github.com/eslint/eslint/issues/5912)) ([#7152](https://github.com/eslint/eslint/issues/7152))
  * Update: Make `indent` report lines with mixed spaces/tabs (fixes [#4274](https://github.com/eslint/eslint/issues/4274)) ([#7076](https://github.com/eslint/eslint/issues/7076))
  * Update: add fixer for `no-regex-spaces` ([#7113](https://github.com/eslint/eslint/issues/7113))
  * Docs: Update PR templates for formatting ([#7128](https://github.com/eslint/eslint/issues/7128))
  * Fix: include LogicalExpression in indent length calc  (fixes [#6731](https://github.com/eslint/eslint/issues/6731)) ([#7087](https://github.com/eslint/eslint/issues/7087))
  * Update: no-implicit-coercion checks TemplateLiterals (fixes [#7062](https://github.com/eslint/eslint/issues/7062)) ([#7121](https://github.com/eslint/eslint/issues/7121))
  * Chore: Enable `typeof` check for `no-undef` rule in eslint-config-eslint ([#7103](https://github.com/eslint/eslint/issues/7103))
  * Docs: Update release process ([#7127](https://github.com/eslint/eslint/issues/7127))
  * Update: `class-methods-use-this`: `exceptions` option (fixes [#7085](https://github.com/eslint/eslint/issues/7085)) ([#7120](https://github.com/eslint/eslint/issues/7120))
  * Fix: line-comment-position "above" string option now works (fixes [#7100](https://github.com/eslint/eslint/issues/7100)) ([#7102](https://github.com/eslint/eslint/issues/7102))
  * Chore: fix name of internal-no-invalid-meta test file ([#7142](https://github.com/eslint/eslint/issues/7142))
  * Docs: Fixes examples for allowTemplateLiterals (fixes [#7115](https://github.com/eslint/eslint/issues/7115)) ([#7135](https://github.com/eslint/eslint/issues/7135))
  * Update: Add `always`/`never` option to `eol-last` (fixes [#6938](https://github.com/eslint/eslint/issues/6938)) ([#6952](https://github.com/eslint/eslint/issues/6952))
  * Docs: Distinguish examples for space-before-blocks ([#7132](https://github.com/eslint/eslint/issues/7132))
  * Chore: Don't require an issue reference in check-commit npm script ([#7104](https://github.com/eslint/eslint/issues/7104))
  * Fix: max-statements-per-line rule to force minimum to be 1 (fixes [#7051](https://github.com/eslint/eslint/issues/7051)) ([#7092](https://github.com/eslint/eslint/issues/7092))
  * Docs: updates category of no-restricted-properties (fixes [#7112](https://github.com/eslint/eslint/issues/7112)) ([#7118](https://github.com/eslint/eslint/issues/7118))
  * Fix: Don't report comparisons of two typeof expressions (fixes [#7078](https://github.com/eslint/eslint/issues/7078)) ([#7082](https://github.com/eslint/eslint/issues/7082))
  * Docs: Fix typos in Issues section of Maintainer's Guide ([#7114](https://github.com/eslint/eslint/issues/7114))
  * Docs: Clarify that linter does not process configuration (fixes [#7108](https://github.com/eslint/eslint/issues/7108)) ([#7110](https://github.com/eslint/eslint/issues/7110))
  * Docs: Elaborate on `guard-for-in` best practice (fixes [#7071](https://github.com/eslint/eslint/issues/7071)) ([#7094](https://github.com/eslint/eslint/issues/7094))
    Explains why a naive `foo.hasOwnProperty(key)` call is a bad idea in the `guard-for-in` page.
    Hopefully prevents future users from being as confused as I was :) (or, maybe worse, ignoring the obscure `{}.hasOwnProperty.call(foo, key)` syntax)
  * Docs: Fix examples for no-restricted-properties ([#7099](https://github.com/eslint/eslint/issues/7099))
  * Docs: Corrected typo in line-comment-position rule doc ([#7097](https://github.com/eslint/eslint/issues/7097))
  * Docs: Add fixable note to no-implicit-coercion docs ([#7096](https://github.com/eslint/eslint/issues/7096))</pre>
