### PR TITLE
Update "es6-promisify" to version 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "changelog": "^1.0.7",
-    "es6-promisify": "4.1.0",
+    "es6-promisify": "5.0.0",
     "github": "3.1.1",
     "npm": "3.10.8",
     "semver": "5.3.0",


### PR DESCRIPTION
<pre>5.0.0 / 2016-09-28
==================

  * 5.0.0
  * Merge pull request [#25](https://github.com/digitaldesignlabs/es6-promisify/issues/25) from digitaldesignlabs/greenkeeper-es6-promise-4.0.3
    Update es6-promise to version 4.0.3 🚀
  * chore(package): update es6-promise to version 4.0.3
    https://greenkeeper.io/
  * Merge pull request [#21](https://github.com/digitaldesignlabs/es6-promisify/issues/21) from digitaldesignlabs/greenkeeper-nodeunit-0.10.0
    Update nodeunit to version 0.10.0 🚀
  * chore(package): update nodeunit to version 0.10.0
    https://greenkeeper.io/
  * ESlint 3 seems to use ES6, which breaks older devices. Blacklist from automatic updates
  * 4.1.1
  * Switching to ESLint</pre>
